### PR TITLE
Fix/ Link to a previous version links to the english guide

### DIFF
--- a/guides/release/getting-started/working-with-html-css-and-javascript.md
+++ b/guides/release/getting-started/working-with-html-css-and-javascript.md
@@ -228,7 +228,7 @@ export default Controller.extend({
 ```
 
 This syntax is known as _classic class_ syntax. You can check out the
-[pre-Octane guides on classic classes](../../../v3.12.0/object-model/)
+[pre-Octane guides on classic classes](https://guides.emberjs.com/v3.12.0/object-model/)
 for more information on how to convert a classic class to modern Ember.
 
 ## Cross-Browser Support

--- a/node-tests/helpers/getNonRelativeGuidesLinks.js
+++ b/node-tests/helpers/getNonRelativeGuidesLinks.js
@@ -1,7 +1,9 @@
 module.exports = function findBadLineBreaks(filepath, links) {
   let results = [];
+  let includeSemver = false;
   links.forEach(function (link) {
-    if (link.includes('guides.emberjs.com/')) {
+    includeSemver = (/v\d+.\d+.\d+/).test(link);
+    if (link.includes('guides.emberjs.com/') && !includeSemver) {
       results.push({ fileToFix: filepath, makeThisARelativePath: link });
     }
   });


### PR DESCRIPTION
## Fix
### Link to a previous version links to the english guide
A relative link of the guide where pointing to an older version we don't have in the French guide. We redirect to the right page of the English guide instead.