### PR TITLE
fix: fix RegExp for matching SemVer

### DIFF
--- a/node-tests/helpers/getNonRelativeGuidesLinks.js
+++ b/node-tests/helpers/getNonRelativeGuidesLinks.js
@@ -1,11 +1,15 @@
+// See: https://semver.org
+const regSemVer = /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/;
+
 module.exports = function findBadLineBreaks(filepath, links) {
   let results = [];
-  let includeSemver = false;
+
   links.forEach(function (link) {
-    includeSemver = (/v\d+.\d+.\d+/).test(link);
+    let includeSemver = regSemVer.test(link);
     if (link.includes('guides.emberjs.com/') && !includeSemver) {
       results.push({ fileToFix: filepath, makeThisARelativePath: link });
     }
   });
+
   return results;
 };


### PR DESCRIPTION
## Fix

### Fix RegExp for matching SemVer (#15)

Yes the RegExp is verbose, but we won't update every day (will we ever actually?).
I could have gone with a more readable `new RegExp(...split group on multiple lines...)` but I don't see the need:
- we know what we want to match
- and the commit's body already provides [help and examples](https://regex101.com/r/vkijKf/1/) to understand the RegExp

1. In the original code, the unescaped `.` was an error.

   An unescaped `.` means "any single character", which was incorrect.
   What we want is to match the literal `.`, so it needs to be escaped.

2. New and suggested RegExp from https://semver.org

   > Is there a suggested regular expression (RegEx) to check a SemVer
   > string?
   >
   > There are two. One with named groups for those systems that support
   > them (PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and
   > R], Python and Go).
   >
   > See: https://regex101.com/r/Ly7O1x/3/
   >
   > And one with numbered capture groups instead (so cg1 = major,
   > cg2 = minor, cg3 = patch, cg4 = prerelease and cg5 = buildmetadata)
   > that is compatible with ECMA Script (JavaScript), PCRE (Perl
   > Compatible Regular Expressions, i.e. Perl, PHP and R), Python and
   > Go.
   >
   > See: https://regex101.com/r/vkijKf/1/
