### PR TITLE
Apply modifications for 4.11 guides

### DIFF
--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -100,7 +100,7 @@ Atom package to use the Ember Language Server.
 Atom autocomplete and snippets for Ember.js.
 
 [atom-ember-snippets](https://github.com/mattmcmanus/atom-ember-snippets) -
-Ember.js ES6, Ember Data & Handlebars snippets for Atom editor.
+Ember.js ES6, EmberData & Handlebars snippets for Atom editor.
 
 [language-ember-htmlbars](https://atom.io/packages/language-ember-htmlbars) -
 Add Ember template syntax highlighting and indentation to Atom

--- a/guides/release/components/index.md
+++ b/guides/release/components/index.md
@@ -148,24 +148,29 @@ body {
 
 form {
   display: grid;
-  grid-column: span 2;
   grid-template-columns: 1fr 6em;
+  grid-template-rows: repeat(2, 1fr);
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  grid-column: span 2;
+}
+
+form > label {
+  grid-area: 1 / 1 / 2 / 2;
 }
 
 form > input {
-  padding: 0.5em;
-  border-top-left-radius: 0.5em;
-  border-bottom-left-radius: 0.5em;
   border: 1px solid #cccccc;
   border-right: none;
   font-size: 1em;
+  grid-area: 2 / 1 / 3 / 2;
 }
 
 form > button {
-  border-top-right-radius: 0.5em;
   border-bottom-right-radius: 0.5em;
   border: 1px solid #cccccc;
   font-size: 1em;
+  grid-area: 2 / 2 / 3 / 3;
 }
 ```
 

--- a/guides/release/contributing/repositories.md
+++ b/guides/release/contributing/repositories.md
@@ -9,7 +9,7 @@ Ember is made up of several libraries. If you wish to add a feature or fix a bug
 
 * [https://github.com/ember-cli/ember-cli](https://github.com/ember-cli/ember-cli)
 
-**Ember Data** - A data persistence library for Ember.
+**EmberData** - A data persistence library for Ember.
 
 * [https://github.com/emberjs/data](https://github.com/emberjs/data)
 

--- a/guides/release/ember-inspector/data.md
+++ b/guides/release/ember-inspector/data.md
@@ -30,4 +30,4 @@ You can also filter records by entering a query in the search box.
 ### Building a Data Custom Adapter
 
 You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/release/classes/DataAdapter) documentation.
+using the Data tab. Use [EmberData's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/release/classes/DataAdapter) documentation.

--- a/guides/release/ember-inspector/object-inspector.md
+++ b/guides/release/ember-inspector/object-inspector.md
@@ -78,7 +78,7 @@ left-facing arrow at the top left.
 ### Custom Property Grouping
 
 Some properties are not only grouped by inheritance, but also
-by framework level semantics. For example, if you inspect an Ember Data
+by framework level semantics. For example, if you inspect an EmberData
 model, you can see `Attributes`, `Belongs To`, `Has Many`, and `Flags`
 groups.
 
@@ -87,5 +87,5 @@ width="450">
 
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
-For an example on how to customize an object's properties, see [Ember Data's
+For an example on how to customize an object's properties, see [EmberData's
 customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/release/getting-started/anatomy-of-an-ember-app.md
+++ b/guides/release/getting-started/anatomy-of-an-ember-app.md
@@ -28,7 +28,7 @@ Par exemple, notre application de gestion de locations devrait pouvoir enregistr
 
 En général, on persiste les informations d'un modèle en les envoyant à un serveur web, bien qu'en réalité il soit possible de les sauvegarder n'importe où ailleurs, comme par exemple dans le "Local Storage" du navigateur.
 
-Par défaut, une nouvelle app Ember inclut [Ember Data](../../models/), une librairie de gestion de données distincte du framework, mais très conventionnelle. Ember Data s'intègre avec Ember et fournit une strate solide pour gérer les modèles.
+Par défaut, une nouvelle app Ember inclut [EmberData](../../models/), une librairie de gestion de données distincte du framework, mais très conventionnelle. EmberData s'intègre avec Ember et fournit une strate solide pour gérer les modèles.
 
 Vous pouvez cependant manipuler vos modèles à l'aide de n'importe quelle autre librairie de gestion de données, comme [Redux](https://github.com/ember-redux/ember-redux) ou
 [Apollo](https://github.com/ember-graphql/ember-apollo-client), ou même créer votre propre système en vous appuyant sur les outils fournis par Ember pour gérer les états, comme [autotracking](../../components/component-state-and-actions/). Nous en apprendrons plus sur ces outils dans d'autres parties du guide.

--- a/guides/release/getting-started/index.md
+++ b/guides/release/getting-started/index.md
@@ -11,7 +11,7 @@ Some of these features that you'll learn about in the guides are:
 * [Components](../components/) - The fundamental construct used in Ember applications, used to create reusable UI elements and define the layout and the functionality of the app.
 * [Routing](../routing/) - A central part of an Ember application. Enables developers to drive the application state from the URL.
 * [Services](../services/) - The way to store long-term state in your application and pass it around.
-* [Ember Data](../models/) - Ember Data provides a consistent way to communicate with external APIs and manage application state
+* [EmberData](../models/) - EmberData provides a consistent way to communicate with external APIs and manage application state
 * [Ember Inspector](../ember-inspector/) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild, try to install it and open up the [NASA website](https://www.nasa.gov/)!
 
 ## Organization

--- a/guides/release/in-depth-topics/making-api-requests.md
+++ b/guides/release/in-depth-topics/making-api-requests.md
@@ -8,7 +8,7 @@ Follow the links within it to see examples and learn more.
 
 Some common tools for making [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) (create, read, update, delete) requests in Ember include:
 
-- [Ember Data](../../models/) is the official data persistence library for Ember. It has a powerful set of tools
+- [EmberData](../../models/) is the official data persistence library for Ember. It has a powerful set of tools
 for formatting requests, normalizing responses, and efficiently
 managing a local cache of data. 
 It is included by default in new Ember apps.

--- a/guides/release/in-depth-topics/native-classes-in-depth.md
+++ b/guides/release/in-depth-topics/native-classes-in-depth.md
@@ -721,7 +721,7 @@ normally would.
 
 One common example is when overriding the
 [`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
-hook in one of Ember Data's serializers.
+hook in one of EmberData's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 

--- a/guides/release/in-depth-topics/patterns-for-components.md
+++ b/guides/release/in-depth-topics/patterns-for-components.md
@@ -169,6 +169,28 @@ or
 {{/each}}
 ```
 
+Or, for example the layout for a SuperForm component might be implemented as:
+
+```handlebars {data-filename=app/components/super-form.hbs}
+<form>
+  {{yield (hash
+    Input=(component "super-input" form=this model=this.model)
+    Textarea=(component "super-textarea" form=this model=this.model)
+    Submit=(component "super-submit" form=this model=this.model)
+  )}}
+</form>
+```
+
+And be used as:
+
+```handlebars {data-filename=app/templates/index.hbs}
+<SuperForm @model={{this.post}} as |f|>
+  <f.Input @name="title" />
+  <f.Textarea @name="body" />
+  <f.Submit />
+</SuperForm>
+```
+
 When the parameter passed to `{{component}}` evaluates to `null` or `undefined`,
 the helper renders nothing. When the parameter changes, the currently rendered
 component is destroyed and the new component is created and brought in.
@@ -176,6 +198,49 @@ component is destroyed and the new component is created and brought in.
 Picking different components to render in response to the data allows you to
 have a different template and behavior for each case. The `{{component}}` helper
 is a powerful tool for improving code modularity.
+
+### Contextual helpers & modifiers
+
+We can even use helpers and modifiers in the same way. Let's extend the SuperForm component:
+
+```handlebars {data-filename=app/components/super-form.hbs}
+<form>
+  {{yield (hash
+
+    Input=(component "super-input" form=this model=this.model)
+    Textarea=(component "super-textarea" form=this model=this.model)
+    Submit=(component "super-submit" form=this model=this.model)
+
+    is-valid=(helper "super-is-valid" form=this model=this.model)
+    error-for=(helper "super-error-for" form=this model=this.model)
+
+    auto-resize=(modifier "super-auto-resize")
+
+  )}}
+</form>
+```
+
+And be used as:
+
+```handlebars {data-filename=app/templates/index.hbs}
+<SuperForm @model={{this.post}} as |f|>
+
+  {{! Invoke a contextual component }}
+  <f.Input @name="title" />
+
+  {{! Invoke contextual helpers }}
+  {{#unless (f.is-valid "title")}}
+    <div class="error">This field {{f.error-for "title"}}</div>
+  {{/unless}}
+
+  {{! Invoke a contextual modifier on a contextual component invocation }}
+  <f.Textarea @name="body" {{f.auto-resize maxHeight="500"}} />
+
+  <f.Submit />
+</SuperForm>
+```
+
+These APIs open the doors for the creation of new, more powerful UI abstractions.
 
 ## Learn More
 

--- a/guides/release/in-depth-topics/rendering-values.md
+++ b/guides/release/in-depth-topics/rendering-values.md
@@ -1,0 +1,87 @@
+In Ember, rendering occurs via syntax, rather than by value -- so _anything_ can be a modifier, helper, or component.
+
+## Modifiers
+
+For Modifiers, there is a specific syntax that only modifiers may reside in
+```hbs
+<div {{someModifier}}>
+```
+or via property on some object
+```hbs
+<div {{this.property.someModifier}}>
+```
+or via an argument passed to a component
+```hbs
+<div {{@someModifier}}>
+```
+
+Modifiers can be curried with the `modifier` helper:
+```hbs
+{{! In a component called "Example" }}
+{{yield (modifier someModifier "arguments" "here")}}
+
+{{! Usage: }}
+<Example as |theModifier|>
+  <div {{theModifier}}>
+</Example>
+```
+
+
+## Helpers
+
+For Helpers, there is a specific syntax that only helpers may reside in
+```hbs
+{{ (theHelper) }}
+```
+or nested in a sub-expression
+```hbs
+{{yield (hash key=(theHelper) key2=(theHelper with args)) }}
+```
+or via property on some object
+```hbs
+{{ (this.property.theHelper) }}
+```
+or via an argument passed to a component
+```hbs
+{{ (@theHelper) }}
+```
+
+Helpers can be curried with the `helper` helper:
+```hbs
+{{! In a component called "Example" }}
+{{yield (helper someHelper "arguments" "here")}}
+
+{{! Usage: }}
+<Example as |theHelper|>
+  {{ (theHelper) }}
+</Example>
+```
+
+## Components
+
+For Components, there is a specific syntax that only components may reside in
+```hbs
+<AComponent />
+```
+or via a property on some object
+```hbs
+<this.someComponent />
+```
+or via an argument passed to a component
+```hbs
+<@someComponent />
+```
+
+Components can be curried with the `component` helper:
+```hbs
+{{!
+  In a component called "Example".
+  Note that components may only receive named arguments
+}}
+{{yield (component someComponent foo="arguments" bar="here")}}
+
+{{! Usage: }}
+<Example as |theComponent|>
+  <theComponent />
+</Example>
+```

--- a/guides/release/index.md
+++ b/guides/release/index.md
@@ -13,7 +13,7 @@ Avec la pléthore de bibliothèques disponibles pour le développement front-end
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="./models/">Ember Data</a>
+		<a href="./models/">EmberData</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>

--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -5,17 +5,17 @@ You can create records by calling the
 method on the store.
 
 ```javascript
-store.createRecord('post', {
+this.store.createRecord('post', {
   title: 'Rails is Omakase',
   body: 'Lorem ipsum'
 });
 ```
 
-The store object is available in controllers and routes using `this.store`.
+To make `store` available, you can [inject the `store` service](../#toc_injecting-the-store).
 
 ## Updating Records
 
-Making changes to Ember Data records is as simple as setting the attribute you
+Making changes to EmberData records is as simple as setting the attribute you
 want to change:
 
 ```javascript
@@ -27,15 +27,15 @@ this.store.findRecord('post', 1).then(function(post) {
 
 ## Persisting Records
 
-Records in Ember Data are persisted on a per-instance basis.
+Records in EmberData are persisted on a per-instance basis.
 Call [`save()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/save?anchor=save)
 on any instance of `Model` and it will make a network request.
 
-Ember Data takes care of tracking the state of each record for
-you. This allows Ember Data to treat newly created records differently
+EmberData takes care of tracking the state of each record for
+you. This allows EmberData to treat newly created records differently
 from existing records when saving.
 
-By default, Ember Data will `POST` newly created records to their type URL.
+By default, EmberData will `POST` newly created records to their type URL.
 
 ```javascript
 let post = store.createRecord('post', {

--- a/guides/release/models/customizing-adapters.md
+++ b/guides/release/models/customizing-adapters.md
@@ -1,18 +1,18 @@
-In Ember Data, an Adapter determines how data is persisted to a
+In EmberData, an Adapter determines how data is persisted to a
 backend data store. Things such as the backend host, URL format
 and headers used to talk to a REST API can all be configured
 in an adapter.
 
-Ember Data's default Adapter has some built-in assumptions about
+EmberData's default Adapter has some built-in assumptions about
 how a [REST API should look](http://jsonapi.org/). If your backend conventions
-differ from those assumptions, Ember Data allows either slight adjustments
+differ from those assumptions, EmberData allows either slight adjustments
 or you can switch to a different adapter if your backend works noticeably
 differently.
 
 _(If you're looking to adjust how the data sent to the backend is formatted,
 check the [serializer](../customizing-serializers/) page.)_
 
-Extending Adapters is a natural process in Ember Data. Ember takes the
+Extending Adapters is a natural process in EmberData. Ember takes the
 position that you should extend an adapter to add different
 functionality. This results in code that is
 more testable, easier to understand and reduces bloat for people who
@@ -48,7 +48,7 @@ export default class PostAdapter extends JSONAPIAdapter {
 }
 ```
 
-Ember Data comes with several built-in adapters.
+EmberData comes with several built-in adapters.
 Feel free to use these adapters as a starting point for creating your own custom adapter.
 
 - [`Adapter`](https://api.emberjs.com/ember-data/release/classes/Adapter) is the basic adapter
@@ -63,7 +63,7 @@ via XHR.
 
 - [`RESTAdapter`](https://api.emberjs.com/ember-data/release/classes/RESTAdapter)
 The `RESTAdapter` allows your store to communicate with an HTTP server
-by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
+by transmitting JSON via XHR. Before EmberData 2.0 this adapter was the default.
 
 
 ## Customizing the JSONAPIAdapter
@@ -188,11 +188,10 @@ underscore_case instead of dash-case you could override the
 
 ```javascript {data-filename=app/adapters/application.js}
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { underscore } from '@ember/string';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   pathForType(type) {
-    return underscore(type);
+    return type.replace(/-/g, '_'); // blog-post-comment becomes blog_post_comment
   }
 }
 ```
@@ -204,7 +203,7 @@ Requests for `user-profile` would now target `/user_profile/1`.
 
 Some APIs require HTTP headers, e.g. to provide an API key. Arbitrary
 headers can be set as key/value pairs on the `JSONAPIAdapter`'s `headers`
-object and Ember Data will send them along with each ajax request.
+object and EmberData will send them along with each ajax request.
 
 ```javascript {data-filename=app/adapters/application.js}
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
@@ -255,9 +254,9 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 
 ## Community Adapters
 
-If none of the built-in Ember Data Adapters work for your backend,
-be sure to check out some of the community maintained Ember Data
-Adapters. Some good places to look for Ember Data Adapters include:
+If none of the built-in EmberData Adapters work for your backend,
+be sure to check out some of the community maintained EmberData
+Adapters. Some good places to look for EmberData Adapters include:
 
 - [Ember Observer](http://emberobserver.com/categories/data)
 - [GitHub](https://github.com/search?q=ember+data+adapter&ref=cmdform)

--- a/guides/release/models/customizing-serializers.md
+++ b/guides/release/models/customizing-serializers.md
@@ -1,10 +1,10 @@
-In Ember Data, serializers format the data sent to and received from
-the backend store. By default, Ember Data serializes data using the
+In EmberData, serializers format the data sent to and received from
+the backend store. By default, EmberData serializes data using the
 [JSON:API](http://jsonapi.org/) format. If your backend uses a different
-format, Ember Data allows you to customize the serializer or use a
+format, EmberData allows you to customize the serializer or use a
 different serializer entirely.
 
-Ember Data ships with 3 serializers. The
+EmberData ships with 3 serializers. The
 [`JSONAPISerializer`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer)
 is the default serializer and works with JSON:API backends. The
 [`JSONSerializer`](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
@@ -117,7 +117,7 @@ should look like this:
 
 ## Customizing Serializers
 
-Ember Data uses the `JSONAPISerializer` by default, but you can
+EmberData uses the `JSONAPISerializer` by default, but you can
 override this default by defining a custom serializer. There are two
 ways to define a custom serializer. First, you can define a custom
 serializer for your entire application by defining an "application"
@@ -142,7 +142,7 @@ export default class PostSerializer extends JSONAPISerializer {
 
 To change the format of the data that is sent to the backend store, you can use
 the [`serialize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
-hook. Let's say that we have this JSON:API response from Ember Data:
+hook. Let's say that we have this JSON:API response from EmberData:
 
 ```json
 {
@@ -257,12 +257,12 @@ To normalize only a single model, you can use the
 [`normalize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
-For more hooks to customize the serializer with, see the [Ember Data serializer
+For more hooks to customize the serializer with, see the [EmberData serializer
 API documentation](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer).
 
 ### IDs
 
-In order to keep track of unique records in the store Ember Data
+In order to keep track of unique records in the store EmberData
 expects every record to have an `id` property in the payload. Ids
 should be unique for every unique record of a specific type. If your
 backend uses a key other than `id` you can use the
@@ -279,7 +279,7 @@ export default class ApplicationSerializer extends JSONAPISerializer {
 
 ### Attribute Names
 
-In Ember Data the convention is to camelize attribute names on a
+In EmberData the convention is to camelize attribute names on a
 model. For example:
 
 ```javascript {data-filename=app/models/person.js}
@@ -318,12 +318,11 @@ payload. For example, if your backend returned attributes that are
 method like this.
 
 ```javascript {data-filename=app/serializers/application.js}
-import { underscore } from '@ember/string';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class ApplicationSerializer extends JSONAPISerializer {
   keyForAttribute(attr) {
-    return underscore(attr);
+    return attr.replace(/_/g, '-'); // blog_post_comment becomes blog-post-comment
   }
 }
 ```
@@ -443,7 +442,7 @@ In some circumstances, the built-in attribute types of `string`,
 `number`, `boolean`, and `date` may be inadequate. For example, a
 server may return a non-standard date format.
 
-Ember Data can have new JSON transforms
+EmberData can have new JSON transforms
 registered for use as attributes:
 
 ```javascript {data-filename=app/transforms/coordinate-point.js}
@@ -497,7 +496,7 @@ Not all APIs follow the conventions that the `JSONAPISerializer` uses
 with a data namespace and sideloaded relationship records. Some
 legacy APIs may return a simple JSON payload that is just the requested
 resource or an array of serialized records. The `JSONSerializer` is a
-serializer that ships with Ember Data that can be used alongside the
+serializer that ships with EmberData that can be used alongside the
 `RESTAdapter` to serialize these simpler APIs.
 
 To use it in your application you will need to define a
@@ -552,7 +551,7 @@ for a full list of methods and properties.
 
 ## EmbeddedRecordMixin
 
-Although Ember Data encourages you to sideload your relationships,
+Although EmberData encourages you to sideload your relationships,
 sometimes when working with legacy APIs you may discover you need to
 deal with JSON that contains relationships embedded inside other
 records. The `EmbeddedRecordsMixin` is meant to help with this problem.
@@ -662,28 +661,28 @@ However, if your payload is extremely different from one of these
 serializers you can create your own by extending the `Serializer`
 base class.
 
-A serializer has two main roles in Ember Data.
+A serializer has two main roles in EmberData.
 First, it is responsible for taking a response from an adapter and
-serializing it into the normalized JSON format that Ember Data
+serializing it into the normalized JSON format that EmberData
 understands.
 Secondly, it transforms snapshots of records into a payload the
 adapter will send to the server when creating, updating, or deleting a
 record.
 
-### Ember Data's Normalized JSON Format
+### EmberData's Normalized JSON Format
 
-The normalized JSON format that Ember Data expects is a
+The normalized JSON format that EmberData expects is a
 [JSON:API](http://jsonapi.org/) document with a couple of additional
 restrictions.
 
 First, it is important to make sure that the `type` name of a record
 in the normalized JSON object exactly matches the filename of the
 model defined for this record type.
-By convention Model names are singular in Ember Data, however, the
+By convention Model names are singular in EmberData, however, the
 example type names shown in the
 [JSON:API spec](http://jsonapi.org/format/) are pluralized.
 The JSON:API spec itself is agnostic about inflection rules, however,
-Ember Data's own `JSONAPISerializer` assumes types are plural and it
+EmberData's own `JSONAPISerializer` assumes types are plural and it
 will automatically singularize the types.
 
 Second, attribute and relationship names in the JSON:API document
@@ -691,19 +690,19 @@ should exactly match the name and casing of the `@attr`,
 `@belongsTo` and `@hasMany`, properties defined on the
 Model.
 
-By convention these property names are camelCase in Ember Data models.
+By convention these property names are camelCase in EmberData models.
 As with the `type` names, this is different from the example attribute
 and relationship names shown in the
 [JSON:API spec](http://jsonapi.org/format/).
 The examples in the spec use dash-case for attribute and relationship
 names. However, the spec does not require attribute or relationship
 names to follow any specific casing convention.
-If you are using Ember Data's own `JSONAPISerializer` it will assume
+If you are using EmberData's own `JSONAPISerializer` it will assume
 the attribute and relationship names from your API are dash-case and
 automatically transform them to camelCase when it creates the
 normalized JSON object.
 
-Other than these two restrictions, Ember Data's normalized JSON object
+Other than these two restrictions, EmberData's normalized JSON object
 follows the [JSON:API](http://jsonapi.org/) specification.
 
 Example: given this `post` model.
@@ -719,7 +718,7 @@ export default class Post extends Model {
 }
 ```
 
-The normalized JSON object that Ember Data expects a serializer to
+The normalized JSON object that EmberData expects a serializer to
 return looks like this:
 
 ```json
@@ -767,7 +766,7 @@ A custom serializer will also need to define a
 [normalize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
-used for normalizing requests made outside of Ember Data because they
+used for normalizing requests made outside of EmberData because they
 do not fall into the normal CRUD flow that the adapter provides.
 
 ### Serializing records
@@ -775,15 +774,15 @@ do not fall into the normal CRUD flow that the adapter provides.
 Finally a serializer will need to implement a
 [serialize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/serialize?anchor=serialize)
 method.
-Ember Data will provide a record snapshot and an options hash and this
+EmberData will provide a record snapshot and an options hash and this
 method should return an object that the adapter will send to the
 server when creating, updating or deleting a record.
 
 
 ## Community Serializers
 
-If none of the built-in Ember Data Serializers work for your backend,
-be sure to check out some of the community maintained Ember Data
+If none of the built-in EmberData Serializers work for your backend,
+be sure to check out some of the community maintained EmberData
 Adapters and Serializers.
 A good place to search for them is
 [Ember Observer](http://emberobserver.com/categories/data).

--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -29,7 +29,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-        Ember Data models are normally setup using the singular form (which is why we use `person` instead of `people` here)
+        EmberData models are normally setup using the singular form (which is why we use `person` instead of `people` here)
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
@@ -77,7 +77,7 @@ match the type you would like to use in your JavaScript code. Ember
 Data allows you to define simple serialization and deserialization
 methods for attribute types called transforms. You can specify that
 you would like a transform to run for an attribute by providing the
-transform name as the first argument to the `attr` method. Ember Data
+transform name as the first argument to the `attr` method. EmberData
 supports attribute types of `string`, `number`, `boolean`, and `date`,
 which coerce the value to the JavaScript type that matches its name.
 
@@ -101,7 +101,7 @@ The `boolean` transform can handle values other than `true` or
 `1` will all coerce to `true`, and `false` otherwise.
 
 Transforms are not required. If you do not specify a transform name
-Ember Data will do no additional processing of the value.
+EmberData will do no additional processing of the value.
 
 #### Custom Transforms
 

--- a/guides/release/models/finding-records.md
+++ b/guides/release/models/finding-records.md
@@ -1,4 +1,4 @@
-The Ember Data store provides an interface for retrieving records of a single type.
+The EmberData store provides an interface for retrieving records of a single type.
 
 ### Retrieving a Single Record
 
@@ -46,7 +46,7 @@ the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 
 ### Querying for Multiple Records
 
-Ember Data provides the ability to query for records that meet certain criteria.
+EmberData provides the ability to query for records that meet certain criteria.
 Calling [`store.query()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
 This method returns a `PromiseArray` in the same way as `findAll`.
 
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
+EmberData provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -106,7 +106,7 @@ store.queryRecord('user', {}).then(function(user) {
 
 As in the case of `store.query()`, a query object can also be passed to `store.queryRecord()` and is available for the adapter's `queryRecord()` to use to qualify the request.
 However the adapter must return a single model object, not an array containing one element,
-otherwise Ember Data will throw an exception.
+otherwise EmberData will throw an exception.
 
 Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 

--- a/guides/release/models/handling-metadata.md
+++ b/guides/release/models/handling-metadata.md
@@ -11,7 +11,7 @@ let result = this.store.query('post', {
 
 To get different _pages_ of data, you'd simply change your offset in increments of 10. So far, so good. But how do you know how many pages of data you have? Your server would need to return the total number of records as a piece of metadata.
 
-Each serializer will expect the metadata to be returned differently. For example, Ember Data's JSON deserializer looks for a `meta` key:
+Each serializer will expect the metadata to be returned differently. For example, EmberData's JSON deserializer looks for a `meta` key:
 
 ```javascript
 {

--- a/guides/release/models/index.md
+++ b/guides/release/models/index.md
@@ -10,11 +10,11 @@ check out the guide for [making API requests](../in-depth-topics/making-api-requ
 look for plugins on [Ember Observer](https://www.emberobserver.com/), and search
 for community-made tutorials.
 
-## What are Ember Data models?
+## What are EmberData models?
 
-In Ember Data, models are objects that represent the underlying data
+In EmberData, models are objects that represent the underlying data
 that your application presents to the user.
-Note that Ember Data models are a different concept than the
+Note that EmberData models are a different concept than the
 [`model`](../routing/specifying-a-routes-model/) method on Routes,
 although they share the same name.
 
@@ -44,27 +44,27 @@ more information about how components get model data, see the
 [Specifying a Route's Model](../routing/specifying-a-routes-model/)
 guide.
 
-At first, using Ember Data may feel different than the way you're used
+At first, using EmberData may feel different than the way you're used
 to writing JavaScript applications. Many developers are familiar with
 using Ajax to fetch raw JSON data from an endpoint, which may appear
 easy at first. Over time, however, complexity leaks out into your
 application code, making it hard to maintain.
 
-With Ember Data, managing models as your application grows becomes both
+With EmberData, managing models as your application grows becomes both
 simpler _and_ easier.
 
-Once you have an understanding of Ember Data, you will have a much
+Once you have an understanding of EmberData, you will have a much
 better way to manage the complexity of data loading in your application.
 This will allow your code to evolve and grow, with better maintainability.
 
-## Ember Data flexibility
+## EmberData flexibility
 
-Thanks to its use of the _adapter pattern_, Ember Data can be configured
+Thanks to its use of the _adapter pattern_, EmberData can be configured
 to work with many different kinds of backends. There is [an entire ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters)
 and several [built-in adapters](./customizing-adapters/)
 that allow your Ember app to talk to different types of servers.
 
-By default, Ember Data is designed to work out of the box with [JSON:API](http://jsonapi.org).
+By default, EmberData is designed to work out of the box with [JSON:API](http://jsonapi.org).
 JSON:API is a formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
@@ -74,12 +74,12 @@ more freedom to change pieces of your stack.
 
 If you need to integrate your Ember.js app with a server that does not
 have an [adapter](http://emberobserver.com/categories/ember-data-adapters) available (for example, you hand-rolled an API server
-that does not adhere to any JSON specification), Ember Data is designed
+that does not adhere to any JSON specification), EmberData is designed
 to **be configurable** to work with whatever data your server returns.
 
-Ember Data is also designed to work with streaming servers, like those
+EmberData is also designed to work with streaming servers, like those
 powered by WebSockets. You can open a socket to your server and push
-changes into Ember Data whenever they occur, giving your app a real-time
+changes into EmberData whenever they occur, giving your app a real-time
 user interface that is always up-to-date.
 
 ## The Store and a Single Source of Truth
@@ -168,7 +168,7 @@ The SOLID principles of good design tell us that objects should have a
 single responsibility. The responsibility of a component should be
 presenting model data to the user, not fetching the model.
 
-Good Ember apps take a different approach. Ember Data gives you a single
+Good Ember apps take a different approach. EmberData gives you a single
 **store** that is the central repository of models in your application.
 Routes and their corresponding controllers can ask the store for models, and the store is
 responsible for knowing how to fetch them.
@@ -182,7 +182,7 @@ first ask the store for it.
 
 ### Injecting the store
 
-Ember Data provides a store service that you can inject into routes, components, services and other classes, that enables you to access the store directly.
+EmberData provides a store service that you can inject into routes, components, services and other classes, that enables you to access the store directly.
 
 To do this, import the [`service` decorator](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/service) and inject a `store` property into your class. Let's see an example using a route:
 
@@ -213,7 +213,7 @@ export default class BlogPostsIndexRoute extends Route {
 
 ## Models
 
-In Ember Data, each model is represented by a subclass of `Model` that
+In EmberData, each model is represented by a subclass of `Model` that
 defines the attributes, relationships, and behavior of the data that you
 present to the user.
 
@@ -321,7 +321,7 @@ of your application have already asked for and loaded it.
 One downside to returning a cached record is you may find the state of
 the data has changed since it was first loaded into the store's
 identity map. In order to prevent this stale data from being a problem
-for long, Ember Data will automatically make a request in the
+for long, EmberData will automatically make a request in the
 background each time a cached record is returned from the store. When
 the new data comes in, the record is updated, and if there have been
 changes to the record since the initial render, the template is
@@ -369,6 +369,6 @@ since it already has it saved locally.
 ---
 
 Models, records, adapters and the store are the core concepts you
-should understand to get the most out of Ember Data. The following
+should understand to get the most out of EmberData. The following
 sections go into more depth about each of these concepts, and how to
 use them together.

--- a/guides/release/models/pushing-records-into-the-store.md
+++ b/guides/release/models/pushing-records-into-the-store.md
@@ -126,7 +126,7 @@ export default class ApplicationRoute extends Route {
 The `push()` method is also important when working with complex
 endpoints. You may find your application has an endpoint that performs
 some business logic then creates several records. This likely does not
-map cleanly to Ember Data's existing `save()` API which is structured
+map cleanly to EmberData's existing `save()` API which is structured
 around persisting a single record. Instead you should make your own
 custom network request and push the resulting model data into the store
 so it can be accessed by other parts of your application.

--- a/guides/release/models/relationships.md
+++ b/guides/release/models/relationships.md
@@ -1,4 +1,4 @@
-Ember Data includes several built-in relationship types to help you
+EmberData includes several built-in relationship types to help you
 define how your models relate to each other.
 
 ### One-to-One
@@ -66,8 +66,8 @@ export default class TagModel extends Model {
 
 ### Explicit Inverses
 
-Ember Data will do its best to discover which relationships map to one
-another. In the one-to-many code above, for example, Ember Data can figure out that
+EmberData will do its best to discover which relationships map to one
+another. In the one-to-many code above, for example, EmberData can figure out that
 changing the `comments` relationship should update the `blogPost`
 relationship on the inverse because `blogPost` is the only relationship to
 that model.
@@ -146,7 +146,7 @@ following example: a user with multiple payment methods. They
 could have a linked PayPal account, and a couple credit cards on
 file.
 
-Note that, for polymorphism to work, Ember Data expects a
+Note that, for polymorphism to work, EmberData expects a
 "type" declaration polymorphic type via the reserved `type`
 property on the model. Confused? See the API response below.
 
@@ -295,7 +295,7 @@ Now, suppose we want to add comments to an existing blogPost. We can do this in 
 let myBlogPost = this.store.peekRecord('blog-post', 1);
 ```
 
-Now we can either set the `belongsTo` relationship in our new comment, or, update the blogPost's `hasMany` relationship. As you might observe, we don't need to set both `hasMany` and `belongsTo` for a record. Ember Data will do that for us.
+Now we can either set the `belongsTo` relationship in our new comment, or, update the blogPost's `hasMany` relationship. As you might observe, we don't need to set both `hasMany` and `belongsTo` for a record. EmberData will do that for us.
 
 First, let's look at setting the `belongsTo` relationship in our new comment:
 
@@ -307,7 +307,7 @@ comment.save();
 ```
 
 In the above snippet, we have referenced `myBlogPost` while creating the record. This will let Ember know that the newly created comment belongs to `myBlogPost`.
-This will create a new `comment` record and save it to the server. Ember Data will also update `myBlogPost` to include our newly created comment in its `comments` relationship.
+This will create a new `comment` record and save it to the server. EmberData will also update `myBlogPost` to include our newly created comment in its `comments` relationship.
 
 The second way of doing the same thing is to link the two records together by updating the blogPost's `hasMany` relationship as shown below:
 
@@ -472,7 +472,7 @@ comments.removeObject(comment);
 blogPost.save();
 ```
 
-As in the earlier examples, the comment's `belongsTo` relationship will also be cleared by Ember Data.
+As in the earlier examples, the comment's `belongsTo` relationship will also be cleared by EmberData.
 
 ### Relationships as Promises
 
@@ -506,4 +506,4 @@ Handlebars templates will automatically be updated to reflect a resolved promise
 </ul>
 ```
 
-Ember Data will query the server for the appropriate records and re-render the template once the data is received.
+EmberData will query the server for the appropriate records and re-render the template once the data is received.

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -53,7 +53,7 @@
           url: "route-params"
         - title: "Injection de Service"
           url: "service-injection"
-        - title: "Ember Data"
+        - title: "EmberData"
           url: "ember-data"
         - title: 'Composants dits "Provider"'
           url: "provider-components"
@@ -119,7 +119,7 @@
   pages:
     - title: Aperçu
       url: "index"
-- title: "Ember Data"
+- title: "EmberData"
   url: "models"
   pages:
     - title: "Introduction"
@@ -157,6 +157,8 @@
       url: "making-api-requests"
     - title: "Classes Natives"
       url: "native-classes-in-depth"
+    - title: "Afficher des valeurs"
+      url: "rendering-values"
 
 - title: "Développement d'une Application"
   url: "toc-heading_application-development"

--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -332,7 +332,7 @@ Router.map(function() {
 In the above example we have successfully used a wildcard route to handle all routes not managed by our application
 so that when a user navigates to `/a/non-existent/path` they will be shown a message that says the page they're looking for wasn't found.
 
-Note that if you want to manually transition to this wildcard route, you need to pass an arbitrary (not empty) argument. For example, using Ember Data to find a record:
+Note that if you want to manually transition to this wildcard route, you need to pass an arbitrary (not empty) argument. For example, using EmberData to find a record:
 
 ```javascript {data-filename=app/routes/some-route.js}
 import Route from '@ember/routing/route';

--- a/guides/release/routing/linking-between-routes.md
+++ b/guides/release/routing/linking-between-routes.md
@@ -205,12 +205,6 @@ simply pass them along with the invocation:
 CSS classes passed this way will be _in addition to_ the standard `ember-view`
 and possibly `active` classes.
 
-Note that the `<LinkTo />` component uses the element's `id` HTML attribute
-internally for event dispatching purposes. For that reason, if you would like
-to customize its HTML `id`, you must pass it as the `@id` argument instead.
-Overriding the components `id` attribute directly will stop the link from
-functioning correctly.
-
 ### Replacing history entries
 
 The default behavior for the `<LinkTo />` component is to add entries to the

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -32,7 +32,7 @@ export default class SlowModelRoute extends Route {
 }
 ```
 
-If you navigate to `slow-model`, in the `model` hook using [Ember Data](../../models/),
+If you navigate to `slow-model`, in the `model` hook using [EmberData](../../models/),
 the query may take a long time to complete.
 During this time, your UI isn't really giving you any feedback as to
 what's happening. If you're entering this route after a full page

--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -14,7 +14,7 @@ representing the current page number in a paginated collection, filter criteria,
 In web development, query parameters are used within a URL as described above but can also be used
 in API requests that retrieve data. Ember treats these as _two_ different concepts. This section
 describes how routing query parameters are used in Ember. See [finding records](../../models/finding-records/#toc_querying-for-multiple-records) to see how query parameters are
-applied to API requests in Ember Data.
+applied to API requests in EmberData.
 
 ### Specifying Query Parameters
 

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -87,10 +87,10 @@ export default class PhotosRoute extends Route {
 }
 ```
 
-### Ember Data example
+### EmberData example
 
-Ember Data is a powerful (but optional) library included by default in new Ember apps.
-In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
+EmberData is a powerful (but optional) library included by default in new Ember apps.
+In the next example, we will use EmberData's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [EmberData records](../../models/).
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';
@@ -105,7 +105,7 @@ export default class FavoritePostsRoute extends Route {
 }
 ```
 
-Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) hook.
+Note that EmberData also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) hook.
 
 ## Multiple Models
 
@@ -184,7 +184,7 @@ export default class PostRoute extends Route {
 }
 ```
 
-If you do not define a model hook for a route, it will default to using Ember Data to look up the record, as shown below:
+If you do not define a model hook for a route, it will default to using EmberData to look up the record, as shown below:
 
 ```js
 model(params) {
@@ -195,7 +195,7 @@ model(params) {
 In the `model` hook for routes with dynamic segments, it's your job to
 turn the ID (something like `47` or `post-slug`) into a model that can
 be rendered by the route's template. In the above example, we use the
-post's ID (`params.post_id`) as an argument to Ember Data's `findRecord`
+post's ID (`params.post_id`) as an argument to EmberData's `findRecord`
 method.
 
 ### Linking to a dynamic segment
@@ -321,4 +321,4 @@ If you are having trouble getting a model's data to show up in the template, her
 - make sure your `model` hook has a `return` statement
 - check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{@model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{@model.title}}` to render it in the template.
 - use your browser's development tools to examine the outgoing and incoming API responses and see if they match what your code expects
-- If you are using Ember Data, use the [Ember Inspector](../../ember-inspector/) browser plugin to explore the View Tree/Model and Data sections.
+- If you are using EmberData, use the [Ember Inspector](../../ember-inspector/) browser plugin to explore the View Tree/Model and Data sections.

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -7,7 +7,7 @@ include:
 * Geolocation.
 * WebSockets.
 * Server-sent events or notifications.
-* Server-backed API calls that may not fit Ember Data.
+* Server-backed API calls that may not fit EmberData.
 * Third-party APIs.
 * Logging.
 

--- a/guides/release/testing/testing-models.md
+++ b/guides/release/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
 in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
+[EmberData](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -107,7 +107,7 @@ module('Unit | Model | user', function(hooks) {
 });
 ```
 
-_Ember Data contains extensive tests around the functionality of
+_EmberData contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests. You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
+look at the [EmberData tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it._

--- a/guides/release/testing/testing-tools.md
+++ b/guides/release/testing/testing-tools.md
@@ -50,22 +50,6 @@ test("should allow disabling the button", async function (assert) {
 });
 ```
 
-### Mocha, Chai DOM
-
-[Mocha](https://mochajs.org/) is another testing framework. If you are more familiar with Mocha, you can install [ember-mocha](https://github.com/emberjs/ember-mocha) and [Chai DOM](https://www.chaijs.com/plugins/chai-dom/) instead.
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        All examples in this guide follow QUnit. Rest assured, the best practices for testing that we present in this guide are independent of your choice of testing framework. Keep in mind, the setup functions from <a href="https://github.com/emberjs/ember-qunit" target="_blank" rel="noopener noreferrer">ember-qunit</a>—<code>setupTest</code>, <code>setupRenderingTest</code>, and <code>setupApplicationTest</code>—need to be replaced with those from <a href="https://github.com/emberjs/ember-mocha" target="_blank" rel="noopener noreferrer">ember-mocha</a>.
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
-
 ### Ember CLI
 
 When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).

--- a/guides/release/testing/unit-testing-basics.md
+++ b/guides/release/testing/unit-testing-basics.md
@@ -29,7 +29,7 @@ Within the test for this object, we'll lookup the service instance, update the `
 should trigger the computed property), and assert that the logic in our
 computed property is working correctly.
 
-```javascript {data-filename=tests/unit/service/some-thing-test.js}
+```javascript {data-filename=tests/unit/services/some-thing-test.js}
 import { module, test } from 'qunit';
 import { setupTest } from 'my-app-name/tests/helpers';
 

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -2,7 +2,7 @@ Native classes are a feature of JavaScript. They are officially supported in
 Ember Octane for use with:
 
 - Components (except classic components)
-- Ember Data Models
+- EmberData Models
 - Routes
 - Controllers
 - Services
@@ -80,7 +80,7 @@ so you should eventually transition to `constructor`.
 
 It's important to note that only _explicit_ injections are available during
 class construction (e.g. injections added using `@service`). If you still rely
-on _implicit_ injections, like Ember Data automatically injecting the `store`
+on _implicit_ injections, like EmberData automatically injecting the `store`
 service, you will need to add it explicitly instead:
 
 ```js

--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -290,7 +290,7 @@ Here are some cases where you still need to use `get` and `set`:
 - When accessing and updating plain properties on objects without decorators
 - When using Ember's `ObjectProxy` class, or a class that implements the
   `unknownProperty` function (which allows objects to intercept `get` calls)
-- When accessing relationships for Ember Data records, e.g. 
+- When accessing relationships for EmberData records, e.g.
 `blogPost.get('comments')`. Under the hood, this is a type of `ObjectProxy`.
 
 Additionally, you will have to continue using _accessor_ functions for arrays if
@@ -381,7 +381,7 @@ available in IE11. Since many Ember users must still support IE11, Ember's
 The use cases for proxies are generally cases where some data is very dynamic,
 and its not possible to know ahead of time how to create a class that is
 decorated. For instance, [`ember-m3`](https://github.com/hjdivad/ember-m3) is an
-addon that allows Ember Data to work with dynamically generated models instead
+addon that allows EmberData to work with dynamically generated models instead
 of models defined using `@attr`, `@hasMany`, and `@belongsTo`. This cuts back on
 code shipped to the browser, but it means that the models have to _dynamically_
 watch and update values. A proxy allows all accesses and updates to be

--- a/guides/versions.yml
+++ b/guides/versions.yml
@@ -1,5 +1,5 @@
 allVersions:
-  - "v4.10.0"
-currentVersion: "v4.10.0"
+  - "v4.11.0"
+currentVersion: "v4.11.0"
 ltsVersions:
   - "v4.4.0"


### PR DESCRIPTION
I modified the French files directly, it was just about `Ember Data -> EmberData` and adding the new section in the menu.

For the record:
```
git diff -R upstream/master -- guides/release > diff
git apply diff
```
- Applying the diff fails by highlighting all the French files that couldn't be patched automatically
- For each file listed:
  - I found the `diff` in the "diff" file and applied manually the modification to the French translation
  - I deleted the `diff` block so it no longer gets in the way of `git apply diff`
- I re-run `git apply diff` to apply automatically the modification to the English files that are not translated yet




