### PR TITLE
Spell linter

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -8,5 +8,6 @@ guides/release/working-with-javascript
 
 # translated only files
 guides/release/**/*.md
+!guides/release/accessibility/learning-resources.md
 !guides/release/applications/index.md
 !guides/release/index.md

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -4,8 +4,8 @@ import remarkRetext from "remark-retext";
 
 import retextLatin from "retext-latin";
 import retextRepeatedWords from "retext-repeated-words";
-import retextSyntaxUrls from "retext-syntax-urls"
-import retextSpell from "retext-spell"
+import retextSyntaxUrls from "retext-syntax-urls";
+import retextSpell from "retext-spell";
 
 import dictionaryFr from "dictionary-fr";
 import { readFileSync } from 'fs';

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -6,6 +6,7 @@ import retextLatin from "retext-latin";
 import retextRepeatedWords from "retext-repeated-words";
 import retextSyntaxUrls from "retext-syntax-urls";
 import retextSpell from "retext-spell";
+import remarkMessageControl from 'remark-message-control';
 
 import dictionaryFr from "dictionary-fr";
 import { readFileSync } from 'fs';
@@ -21,6 +22,10 @@ const remarkConfig = {
         .use(retextSpell, {
           dictionary: dictionaryFr,
           personal: readFileSync("./.local.dic"),
+        })
+        .use(remarkMessageControl, {
+          name: 'spell',
+          sources: ['retext-spell']
         })
     ],
     "remark-preset-lint-consistent",

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,12 +1,11 @@
 /* eslint-env node */
 import { unified } from "unified";
-import remarkRetext from "remark-retext"; 
+import remarkRetext from "remark-retext";
 
 import retextLatin from "retext-latin";
 import retextRepeatedWords from "retext-repeated-words";
 import retextSyntaxUrls from "retext-syntax-urls";
 import retextSpell from "retext-spell";
-import remarkMessageControl from 'remark-message-control';
 
 import dictionaryFr from "dictionary-fr";
 import { readFileSync } from 'fs';
@@ -22,17 +21,14 @@ const remarkConfig = {
         .use(retextSpell, {
           dictionary: dictionaryFr,
           personal: readFileSync("./.local.dic"),
-        })
-        .use(remarkMessageControl, {
-          name: 'spell',
-          sources: ['retext-spell']
-        })
+        }),
     ],
     "remark-preset-lint-consistent",
     "remark-preset-lint-recommended",
     ["remark-lint-list-item-indent", "space"],
     ["remark-lint-list-item-bullet-indent", false],
     ["remark-lint-code-block-style", false],
+    ["remark-message-control", { name: 'spell', source: ['retext-spell'] }],
   ]
 };
 

--- a/guides/release/accessibility/learning-resources.md
+++ b/guides/release/accessibility/learning-resources.md
@@ -4,7 +4,7 @@ Ces ressources d'apprentissage sur l'accessibilité ont pour but d'apporter une 
 
 - [Documentation Web MDN: Accessibilité](https://developer.mozilla.org/fr/docs/Learn/Accessibility)
 
-<!--spell ignore-->
+<!-- spell ignore -->
 - [Using ARIA](https://www.w3.org/TR/using-aria/) : un guide pratique pour ajouter aux éléments HTML des informations accessibles.
 - [Web Content Accessibility Guidelines(WCAG) : Directives du contenu web sur l'accessibilité 2.1](https://www.w3.org/TR/WCAG21/)
 - [Accessible Rich Internet Applications (ARIA) : Applications Internet Riches et Accessibles 1.1](https://www.w3.org/TR/wai-aria-1.1/)
@@ -12,10 +12,10 @@ Ces ressources d'apprentissage sur l'accessibilité ont pour but d'apporter une 
 
 ## Ressources pratiques
 
-- [Accessibility Insights](https://accessibilityinsights.io/)- Utiliser FastPass pour trouver des problèmes communs à fort impact
+- <!-- spell ignore -->[Accessibility Insights](https://accessibilityinsights.io/)- Utiliser FastPass pour trouver des problèmes communs à fort impact
 - [Extension aXe pour Chrome](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd)
-- [Accessibility Support](https://a11ysupport.io/)- Comprendre si son code marche avec les technologies d'assistance
-- [How and where to report accessibility bugs](https://www.digitala11y.com/how-where-to-report-accessibility-bugs/)
+- <!-- spell ignore -->[Accessibility Support](https://a11ysupport.io/)- Comprendre si son code marche avec les technologies d'assistance
+- <!-- spell ignore -->[How and where to report accessibility bugs](https://www.digitala11y.com/how-where-to-report-accessibility-bugs/)
 
 
 ### Design
@@ -31,4 +31,5 @@ Ces ressources d'apprentissage sur l'accessibilité ont pour but d'apporter une 
 
 ### Autres articles utiles
 
+<!-- spell ignore -->
 - [The difference between keyboard and screen reader navigation](https://tink.uk/the-difference-between-keyboard-and-screen-reader-navigation/)

--- a/guides/release/accessibility/learning-resources.md
+++ b/guides/release/accessibility/learning-resources.md
@@ -4,6 +4,7 @@ Ces ressources d'apprentissage sur l'accessibilité ont pour but d'apporter une 
 
 - [Documentation Web MDN: Accessibilité](https://developer.mozilla.org/fr/docs/Learn/Accessibility)
 
+<!--spell ignore-->
 - [Using ARIA](https://www.w3.org/TR/using-aria/) : un guide pratique pour ajouter aux éléments HTML des informations accessibles.
 - [Web Content Accessibility Guidelines(WCAG) : Directives du contenu web sur l'accessibilité 2.1](https://www.w3.org/TR/WCAG21/)
 - [Accessible Rich Internet Applications (ARIA) : Applications Internet Riches et Accessibles 1.1](https://www.w3.org/TR/wai-aria-1.1/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "qunit-dom": "^1.6.0",
         "remark-cli": "^11.0.0",
         "remark-lint": "^9.1.1",
+        "remark-message-control": "^7.1.1",
         "remark-preset-lint-consistent": "^5.1.1",
         "remark-preset-lint-recommended": "^6.1.2",
         "remark-retext": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "qunit-dom": "^1.6.0",
     "remark-cli": "^11.0.0",
     "remark-lint": "^9.1.1",
+    "remark-message-control": "^7.1.1",
     "remark-preset-lint-consistent": "^5.1.1",
     "remark-preset-lint-recommended": "^6.1.2",
     "remark-retext": "^5.0.1",


### PR DESCRIPTION
### Allow the linter to ignore English titles in links

As part of  #169, we followed the suggestion in [retextjs/discussions/89](https://github.com/orgs/retextjs/discussions/89) and we installed [remark-message-control ](https://github.com/remarkjs/remark-message-control) to build a linter rule that will ignore the spelling for the next block or the current line.

In practice, `<!-- spell ignore -->` should be used to ignore complete article titles that we decided to let in English. If a French sentence contains a technical word or English word that is commonly used in French, we should rather add it to the local dictionary. 
