### PR TITLE
Share pre-commit hook warning about missing file to lint

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+SRC_PATTERN="guides/release/"
+changes=`git diff --cached --name-only | grep "$SRC_PATTERN"`
+for translated in $changes; do
+  while read -r line; do
+    if [ "!$translated" = "$line" ]; then
+      exit 0
+    fi
+  done < ".remarkignore"
+  echo "******* WARNING *******"
+  echo "Check your spelling ;)"
+  echo You translated the file:
+  echo $translated
+  echo But it is not present in .remarkignore
+  echo "***********************"
+done
+exit 0


### PR DESCRIPTION
This PR shares the first version of a git hook to remember adding the translation file modified in the commit to `.remarkignore`. An issue will be opened to improve it. Closes #169

git >= 2.9
- Run `git config core.hooksPath .githooks`

git < 2.9
- Copy the hook in `.githooks/` to `.git/hooks/`