### PR TITLE
Integrate zoey

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -205,3 +205,6 @@ li.toc-heading.toc-level-0:first-of-type {
 li.toc-group.toc-level-0 {
   padding-left: 1em;
 }
+
+/* Override guimaker-ember-locale-template style */
+// Add some rules specific to the French teplate

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -206,5 +206,5 @@ li.toc-group.toc-level-0 {
   padding-left: 1em;
 }
 
-/* Override guimaker-ember-locale-template style */
-// Add some rules specific to the French teplate
+/* Override `guidemaker-ember-locale-template` style */
+// Add some rules specific to the French template

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "eslint-plugin-qunit": "^6.2.0",
         "gfm-code-blocks": "^1.0.0",
         "guidemaker": "^2.4.0",
-        "guidemaker-default-template": "^5.0.0",
+        "guidemaker-ember-locale-template": "git://github.com/DazzlingFugu/guidemaker-ember-locale-template#main",
         "loader.js": "^4.7.0",
         "lodash": "^4.17.21",
         "markdown-link-extractor": "^1.2.2",
@@ -80,135 +80,6 @@
       },
       "engines": {
         "node": ">= 16"
-      }
-    },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
-      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
-      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ==",
-      "dev": true
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
-      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
-      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/transporter": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
-      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
-      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
-      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
-      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
-      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ==",
-      "dev": true
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
-      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/logger-common": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
-      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
-      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw==",
-      "dev": true
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
-      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.16.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
-      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.16.0",
-        "@algolia/logger-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -25972,11 +25843,12 @@
         "node": "10.* || >= 12"
       }
     },
-    "node_modules/guidemaker-default-template": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/guidemaker-default-template/-/guidemaker-default-template-5.0.0.tgz",
-      "integrity": "sha512-cX4pwn9xlKkOhZkNJD6rGFsSo8k0Rms0E5Upqfkyfyw3C19vbSmHMYnV5thwfcFmt18pT+WN/aB2A4BzKpQqvw==",
+    "node_modules/guidemaker-ember-locale-template": {
+      "name": "guidemaker-default-template",
+      "version": "5.1.0",
+      "resolved": "git+ssh://git@github.com/DazzlingFugu/guidemaker-ember-locale-template.git#f851e9a868a3c18710244605f2e5ec7f65475e88",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "algoliasearch": "^4.0.0",
         "broccoli-funnel": "^3.0.2",
@@ -25998,29 +25870,158 @@
         "node": "12.* || 14.* || >= 16"
       }
     },
-    "node_modules/guidemaker-default-template/node_modules/algoliasearch": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
-      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.17.0.tgz",
+      "integrity": "sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.16.0",
-        "@algolia/cache-common": "4.16.0",
-        "@algolia/cache-in-memory": "4.16.0",
-        "@algolia/client-account": "4.16.0",
-        "@algolia/client-analytics": "4.16.0",
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-personalization": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/logger-common": "4.16.0",
-        "@algolia/logger-console": "4.16.0",
-        "@algolia/requester-browser-xhr": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/requester-node-http": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/cache-common": "4.17.0"
       }
     },
-    "node_modules/guidemaker-default-template/node_modules/ember-truth-helpers": {
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/cache-common": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.17.0.tgz",
+      "integrity": "sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ==",
+      "dev": true
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/cache-in-memory": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.17.0.tgz",
+      "integrity": "sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/client-account": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.17.0.tgz",
+      "integrity": "sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/transporter": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/client-analytics": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.17.0.tgz",
+      "integrity": "sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/client-common": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.17.0.tgz",
+      "integrity": "sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/client-personalization": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.17.0.tgz",
+      "integrity": "sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/client-search": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.17.0.tgz",
+      "integrity": "sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/logger-common": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.17.0.tgz",
+      "integrity": "sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw==",
+      "dev": true
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/logger-console": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.17.0.tgz",
+      "integrity": "sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/logger-common": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.17.0.tgz",
+      "integrity": "sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/requester-common": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.17.0.tgz",
+      "integrity": "sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg==",
+      "dev": true
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/requester-node-http": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.17.0.tgz",
+      "integrity": "sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/@algolia/transporter": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.17.0.tgz",
+      "integrity": "sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/algoliasearch": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.17.0.tgz",
+      "integrity": "sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.17.0",
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/cache-in-memory": "4.17.0",
+        "@algolia/client-account": "4.17.0",
+        "@algolia/client-analytics": "4.17.0",
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-personalization": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/logger-console": "4.17.0",
+        "@algolia/requester-browser-xhr": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/requester-node-http": "4.17.0",
+        "@algolia/transporter": "4.17.0"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/ember-truth-helpers": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
       "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "ember-cli-htmlbars": "^5.7.2",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-netlify": "^0.4.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-data": "~3.28.6",
@@ -75,6 +76,7 @@
         "retext-repeated-words": "^4.2.0",
         "retext-spell": "^5.3.0",
         "retext-syntax-urls": "^3.1.2",
+        "sass": "^1.62.1",
         "unified": "^10.1.2",
         "walk-sync": "^2.0.2"
       },
@@ -14761,9 +14763,9 @@
       }
     },
     "node_modules/ember-cli-sass": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-      "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-11.0.1.tgz",
+      "integrity": "sha512-RMlFPMK4kaB+67seF/IIoY3EC4rRd+L58q+lyElrxB3FcQTgph/qmGwtqf9Up7m3SDbPiA7cccCOSmgReMgCXA==",
       "dev": true,
       "dependencies": {
         "broccoli-funnel": "^2.0.1",
@@ -14772,7 +14774,7 @@
         "ember-cli-version-checker": "^2.1.0"
       },
       "engines": {
-        "node": "6.* || 8.* || >= 10.*"
+        "node": ">= 10.*"
       }
     },
     "node_modules/ember-cli-sass/node_modules/broccoli-funnel": {
@@ -26021,6 +26023,58 @@
         "@algolia/transporter": "4.17.0"
       }
     },
+    "node_modules/guidemaker-ember-locale-template/node_modules/ember-cli-sass": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
+      "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^3.0.1",
+        "broccoli-sass-source-maps": "^4.0.0",
+        "ember-cli-version-checker": "^2.1.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/ember-cli-sass/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/ember-cli-version-checker": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.3.3",
+        "semver": "^5.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/guidemaker-ember-locale-template/node_modules/ember-truth-helpers": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
@@ -26031,6 +26085,49 @@
       },
       "engines": {
         "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/guidemaker-ember-locale-template/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
       }
     },
     "node_modules/guidemaker/node_modules/@embroider/shared-internals": {
@@ -35598,9 +35695,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
-      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
+      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -35611,7 +35708,7 @@
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/sax": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-qunit": "^6.2.0",
     "gfm-code-blocks": "^1.0.0",
     "guidemaker": "^2.4.0",
-    "guidemaker-default-template": "^5.0.0",
+    "guidemaker-ember-locale-template": "git://github.com/DazzlingFugu/guidemaker-ember-locale-template#main",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "markdown-link-extractor": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-cli-htmlbars": "^5.7.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-netlify": "^0.4.1",
+    "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~3.28.6",
@@ -97,6 +98,7 @@
     "retext-repeated-words": "^4.2.0",
     "retext-spell": "^5.3.0",
     "retext-syntax-urls": "^3.1.2",
+    "sass": "^1.62.1",
     "unified": "^10.1.2",
     "walk-sync": "^2.0.2"
   },


### PR DESCRIPTION
### Install a new `guidemaker` template to get Zoey back
This PR replaces `guidemaker-default-template` with `guidemaker-ember-locale-template` to get Zoey informational boxes displayed correctly. Closes #182

[`guidemaker-ember-locale-template`](https://github.com/DazzlingFugu/guidemaker-ember-locale-template) is a new fork of [`guidemaker-default-template`](https://github.com/empress/guidemaker-default-template). We should think of it as a generic alternative Ember template for translation projects like this one.

[`guidemaker-ember-locale-template#1`](https://github.com/DazzlingFugu/guidemaker-ember-locale-template/pull/1) integrates a `<Note />` component inspired by [ember-styleguide](https://github.com/ember-learn/ember-styleguide/)'s `<EsNote />` that display the informational notes with the mascot's head.

<img width="884" alt="Capture d’écran 2023-05-05 à 18 29 47" src="https://user-images.githubusercontent.com/22059380/236514829-33c95fb6-4643-4155-bb84-285e70c64aa3.png">

### Install `ember-cli-sass`
Using `ember-cli-sass` will ease our life to eventually override some CSS from `guidemaker-ember-locale-template` if we want some styling to be French-specific. 