### PR TITLE
Add the permission to use the images in the footer

### DIFF
--- a/app/components/guidemaker-footer.hbs
+++ b/app/components/guidemaker-footer.hbs
@@ -3,6 +3,7 @@
       <div class="container space-between">
         <div class="footer-info flex-1">
           {{if this.guidemaker.copyright this.guidemaker.copyright this.guidemaker.title}} &copy; {{this.currentYear}}
+          <p>Ember, le design du logo Ember et les design de Tomster sont des marques déposées aux États-Unis par Tilde Inc. Elles sont utilisées sur ce site avec la permission de Tilde Inc. et du projet Ember.</p>
         </div>
         <div class="footer-statement footer-middle">
           <p>Ce site web est une traduction libre de <a href="https://guides.emberjs.com" target="_blank" rel="noopener noreferrer">Ember.js Guides</a> maintenue par quelques membres enthousiastes de la communauté française Ember.</p>


### PR DESCRIPTION
Now that we plan to present this project at Ember Fest, it could get more views than just us so it's important we catch-up with the legal part. I asked `@`wifelette the permission to use the logo and the Tomster images. 

She said it's ok and she asked me to write a note in the application footer:

> just write something equivalent [to what the branding page says] in French acknowledging that the logo, Tomster, Zoey, etc. are owned by and used with permission from Tilde Inc and the Ember Project.