### PR TITLE
New nicer version of the catchup script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "chai": "^4.3.4",
+        "chalk": "^5.3.0",
         "dictionary-fr": "^2.8.0",
         "dotenv": "^16.3.1",
         "ember-auto-import": "^2.6.1",
@@ -80,7 +81,6 @@
         "retext-spell": "^5.3.0",
         "retext-syntax-urls": "^3.1.2",
         "sass": "^1.62.1",
-        "shelljs": "^0.8.5",
         "unified": "^10.1.2",
         "walk-sync": "^2.0.2"
       },
@@ -2732,6 +2732,22 @@
         "node": "10.* || >= 12.*"
       }
     },
+    "node_modules/@ember-data/private-build-infra/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@ember-data/private-build-infra/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3483,6 +3499,22 @@
       },
       "engines": {
         "node": "10.* || 12.* || >= 14"
+      }
+    },
+    "node_modules/@ember/optional-features/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@ember/render-modifiers": {
@@ -10117,16 +10149,12 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -15535,6 +15563,76 @@
       },
       "engines": {
         "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ember-cli/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ember-cli/node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ember-cli/node_modules/chalk/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ember-cli/node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-cli/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ember-cli/node_modules/color-convert": {
@@ -21110,6 +21208,76 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ember-source/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ember-source/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ember-source/node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ember-source/node_modules/chalk/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ember-source/node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-source/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ember-source/node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -21308,6 +21476,22 @@
         "node": ">= 10.24 < 11 || 12.* || >= 14.*"
       }
     },
+    "node_modules/ember-template-lint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/ember-template-lint/node_modules/ci-info": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
@@ -21458,6 +21642,22 @@
       "dependencies": {
         "@glimmer/env": "^0.1.7",
         "@glimmer/global-context": "0.65.4"
+      }
+    },
+    "node_modules/ember-template-recast/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ember-template-recast/node_modules/commander": {
@@ -23499,6 +23699,22 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/debug": {
@@ -27929,6 +28145,22 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
@@ -30687,6 +30919,34 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/mocha/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/mocha/node_modules/chokidar": {
       "version": "3.5.1",
@@ -38342,18 +38602,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unified-args/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/unified-engine": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.3.4",
+    "chalk": "^5.3.0",
     "dictionary-fr": "^2.8.0",
     "dotenv": "^16.3.1",
     "ember-auto-import": "^2.6.1",
@@ -113,7 +114,6 @@
     "retext-spell": "^5.3.0",
     "retext-syntax-urls": "^3.1.2",
     "sass": "^1.62.1",
-    "shelljs": "^0.8.5",
     "unified": "^10.1.2",
     "walk-sync": "^2.0.2"
   },

--- a/scripts/catchup.mjs
+++ b/scripts/catchup.mjs
@@ -1,511 +1,192 @@
-import 'dotenv/config';
-import { execSync } from 'child_process';
-import fs from 'fs';
-import minimist from 'minimist-lite';
+import 'dotenv/config'
+import chalk from 'chalk'
+import fs from 'fs'
+import minimist from 'minimist-lite'
+import { processFiles } from './catchup/filesProcessor.mjs'
+import { initCatchup, pushGuides, updateRefUpstream } from './catchup/gitActions.mjs'
+import GitHubAdapter from './catchup/github.mjs'
+import { log, raise, success, warn, runShell, printActionsRequired, action } from './catchup/logger.mjs'
 
-// Declare repository
-const repo = 'DazzlingFugu/ember-fr-guides-source';
+/* ------------------------------------------------------------------ */
+const REPO = 'DazzlingFugu/ember-fr-guides-source'
+/* ------------------------------------------------------------------ */
 
-// Read Github token
-const token = process.env.GITHUB_TOKEN;
-
-/*
- * Read script arguments
- * We expect options "from" and "to" to have decimal values (e.g. 5.4, 6.0...)
- * By default, minimist-lite would treat these values as numbers so "6.0" would be parsed as "6".
- * This is not the intended behavior, so we specify that "from" and "to" should be treated as strings.
- */
 const argv = minimist(process.argv.slice(2), { string: ['from', 'to'] });
 
 // Read current Ember version (under translation)
 const currentEmberVersion = `${argv.from}`;
 if (currentEmberVersion.match(/\d+[.]\d+/g)?.[0] !== currentEmberVersion) {
-  console.error('Error: please provide the current Ember version under translation to option --from (e.g. --from=5.1)');
+  raise(`please provide the current Ember version under translation to option ${chalk.cyan.bold('--from')} (e.g. --from=5.1)`)
   process.exit(9);
 }
-console.log(`Ember version under translation: ${currentEmberVersion}`);
+log(`Ember version under translation: ${chalk.cyan.bold(currentEmberVersion)}`);
 
 // Read new Ember version (documented by the English guides)
 const newEmberVersion = `${argv.to}`;
 if (newEmberVersion.match(/\d+[.]\d+/g)?.[0] !== newEmberVersion) {
-  console.error('Error: please provide the new Ember version documented on upstream to option --to (e.g. --to=5.4)');
+  raise(`please provide the new Ember version documented on upstream to option ${chalk.cyan.bold('--to')} (e.g. --to=5.4)`)
   process.exit(9);
 }
-console.log(`New Ember version documented on upstream: ${newEmberVersion}`);
+log(`New Ember version documented on upstream: ${chalk.cyan.bold(newEmberVersion)}`);
 
 // Name of the catchup branch we will work on
 const catchupBranch = `catchup-${newEmberVersion}`;
 
-// List of filenames that changed between origin/ref-upstream and upstream/master
-let files;
+function fsIssueOnApplyPatches() {
+  return action(`Something went wront while processing the patch files, so you can choose one of the following options:
+-> Go back to master branch, delete this branch and try to rerun the script.
+  If you run into the same result, investigate what part of the script cause the problem, or complete the catchup manually.
+  To complete the catchup manually:
+-> Follow all the ACTION REQUIRED above to process the patch files manually.
+  If the present catchup branch has changes in the guides folder, run:
+  * git add guides
+  * git commit -m "feat: automatic catch up from ${currentEmberVersion} to ${newEmberVersion}"
+  * git push origin ${catchupBranch}
+  * Then open the catchup PR on GitHub
+  -> Once this is done, run:
+    * git switch ref-upstream
+    * git reset --hard upstream/master
+    * git push origin -f ref-upstream
 
-/* 
- * List of { filename, diffname } that require a GitHub issue to be adjusted manually
- * Example:
- * { filename: "my-page.md", diffName: "3.diff" } 
- * This mean that the diff between origin/ref-upstream and upstream/master for the file "my-page.md"
- * has been printed in "3.diff".
- * The command "git apply 3.diff" failed, probably because "my-page.md" was already translated into French.
- * Therefore, we need to open a GitHub issue showing the diff English to English so translators know how to adjust the translation.
- */
-let filesToPost = [];
-
-// List of manual actions to perform if the script encounters some failures
-let warnings = [];
-
-// True if the ref-upstream branch cannot be updated because we need some manual checks between ref-upstream and upstream/master
-let hasPendingDiff = false;
-
-// Some issues haven't been posted on Github, so it would be neat to stay on the catchup branch at the end of the process
-let issuePostingError = false;
-
-/* 
- * This function executes a shell command using execSync with an additional log.
- * If the command failed, execSync throws the error, so use runShell inside a try...catch.
- */
-const runShell = (command) => {
-  console.log(`Attempting to execute: "${command}"`);
-  execSync(command);
+  `)
 }
 
-/*
- * This function prints the messages stored in warnings.
- * It should always be called before forcing the process to exit.
- */
-const printWarningMessages = () => {
-  if (warnings.length > 0) {
-    console.log(`
-The process has been completed with warnings.
-Here are all the actions you should perform manually to fully complete it:
+function gitIssueOnPushGuides() {
+  return action(`Failed to push the catchup branch
+-> Check what's the issue, then push the changes and open the Github PR manually:
+  * git add guides
+  * git commit -m "feat: automatic catch up from ${currentEmberVersion} to ${newEmberVersion}"
+  * git push origin ${catchupBranch}
+  * Then open the catchup PR on GitHub
 
-`);
-    for (const warning of warnings) {
-      console.warn(warning);
-    };
-  }
+`)
 }
 
-/*
- * This function looks for the paths guides/release in the provided string and replace it with guides.
- * We need this to adjust the paths to our scaffolding:
- * The official English guides allow to navigate to legacy versions of Ember, it's "versioned" docs.
- * The French guides show only the latest version, so we don't have a dropdown to navigate, it's "unversioned" docs.
- * It's the scaffolding of the guides folder that impacts the dropdown presence: instead of having a release/ folder
- * that corresponds to the latest version, we have the docs at the root of guides directly.
- */
-const unversionPath = (stringContent) => {
-  return stringContent.replace(/guides\/release/g, 'guides');
+function requestIssueOnOpenPR() {
+  return action(`The catchup PR was not opened automatically on GitHub.
+-> Check what's the issue, then open the PR on GitHub manually.
+
+  `)
 }
 
-/* 
- * This function compares the given filename in both branches and output a [index].diff file.
- * Example: 
- * filename = guides/accessibility/index.md, index = 3
- * The diff between ref-upstream and upstream/master for this file is printed in 3.diff
- */
-const createDiff = (filename, index) => {
-  const diffName = `scripts/patches/${index}.diff`;
-  try {
-    runShell(`git diff ref-upstream upstream/master -- ${filename} > ${diffName}`);
-    return diffName;
-  } catch (error) {
-    warnings.push(`
-ACTION REQUIRED: The diff file was not created for ${filename}.
--> Check manually if there is a diff to handle between origin/ref-upstream and upstream/master for this file.
-
-`);
-    throw new Error(`Failed to create the diff for ${filename}. This was caused by: ${err}`);
-  }
-}
-
-/* 
- * This function executes all the read/write/unlink operations on diff files.
- *
- * files is the list of files (as path) that changed between ref-upstream and upstream/master
- * filesToPost is an empty array of objects { filename, diffName } this function is in charge to fill,
- * it will keep track of all the files whose diff can't be applied automatically, and we will reuse it
- * to post Github issues.
- */
-const writeDiffFiles = async () => {
-  let writePromises = files.map(async (filename, index) => {
-    return new Promise((resolve) => {
-      let diffName;
-      try {
-        diffName = createDiff(filename, index);
-      } catch (error) {
-        console.warn(error);
-        resolve(1);
-      }
-      // Read the created diff file, we need to access its content to adjust it to our Guidemaker scaffolding
-      fs.readFile(diffName, 'utf8', function(err, data) {
-        if (err) {
-          warnings.push(`
-ACTION REQUIRED: The patch paths could not be edited for ${diffName} because the file couldn't be read.
--> Check what's the issue then edit the path manually:
-* Find and replace "guides/release" with "guides" in ${diffName}
-* Run "git apply ${diffName}"
-    If the command is successful, commit the file.
-    If the command fails, open a GitHub issue and copy the diff using the provided issue template.
-
-`);
-          console.warn(`Failed to read ${diffName} to edit the patch path. This was caused by: ${err}`);
-          resolve(1);
-        }
-
-        // Matching Guidemaker scaffolding consists in replacing path guides/release with guides
-        const unversionedFileName = unversionPath(filename);
-        const replacement = unversionPath(data);
-
-        fs.writeFile(diffName, replacement, 'utf8', function(err) {
-          if (err) {
-            warnings.push(`
-ACTION REQUIRED: The patch paths could not be edited for ${diffName} because the file couldn't be edited.
--> Check what's the issue then edit the path manually:
- * Find and replace "guides/release" with "guides" in ${diffName}
- * Run "git apply ${diffName}"
-   If the command is successful, commit the file.
-   If the command fails, open a GitHub issue and copy the diff using the provided issue template.
-            
-            `);
-            console.warn(`Failed to write ${diffName} to edit the patch path. This was caused by: ${err}`);
-            resolve(1);
-          }
-          console.log(`Path in ${diffName} updated`);
-
-          // Once diff paths are ready, run "git apply" to patch the markdown file automatically
-          try {
-            // Does the current file already exist or is it a new page in the Ember Guides?
-            let isNew = !fs.existsSync(unversionedFileName);
-            // git apply runs after we've initialized isNew, because it can create the missing file
-            runShell(`git apply ${diffName}`);
-            // If the page is new, git apply works but we still need to push an issue
-            if (isNew) filesToPost.push({ filename: unversionedFileName });
-            // Remove the file if the apply was successfull
-            fs.unlink(diffName, function(err) {
-              if (err) {
-                console.warn(err);
-              } else {
-                console.log(`${diffName} handled and deleted`);
-              }
-            });
-            resolve(0);
-          } catch (error) {
-            console.log(`"git apply" command failed for ${diffName}`);
-            filesToPost.push({ filename: unversionedFileName, diffName });
-            resolve(2);
-          }
-        });
-      });
-    });
-  });
-  console.log('Ready to create the patch files');
-  return Promise.all(writePromises).then((result) => {
-    const hasErrors = result.some((status) => status === 1);
-    if (hasErrors) {
-      hasPendingDiff = true;
-      console.warn('Writing operations have been completed with errors. Some of the patch files are applied or stored in scripts/patches/, and manual actions have been added to the warning list.');
-    } else {
-      console.log('All writing operations have been completed without errors, patch files are applied or stored in scripts/patches/');
-    }
-    return result.some((status) => status === 0);
-  });
-}
-
-/* 
- * This function returns the headers required for all requests to GitHub API.
- * It includes both posting issues and opening the catchup PR.
- */
-const getRequestHeaders = () => {
-  return {
-    'Accept': 'application/vnd.github+json',
-    'Authorization': `token ${token}`,
-    'X-GitHub-Api-Version': '2022-11-28'
-  }
-}
-
-/* 
- * This function generates the body of the Github issues posted by postIssue function.
- * Note the diffBlock can be undefined if the file was initially non-existing in origin/ref-upstream branch,
- * this case happens when new pages are added to the latest version of the Ember Guides.
- */
-const getIssueBody = (filename, diffblock) => {
-  diffblock = diffblock 
-    ? `
-In the snippet below, you can see what changes were done in the latest English documentation. The purpose of this issue is to adjust the French translation to match the new version:
-
-\`\`\`diff
-${diffblock}
-\`\`\`
-`
-    : 'This is the first translation for this file.';
-  return `
-Please assign yourself to the issue or let a comment at the very moment you start the translation.
-      
-File: \`${filename}\`
-From Ember: **${currentEmberVersion}**
-To Ember: **${newEmberVersion}**
-
-${diffblock}
-`
-}
-
-// This function posts a GitHub issue related to the given file
-const postIssue = (file) => {
-  const { filename, diffName } = file;
-  const shorterName = filename.substring(6);
-
-  let diffblock;
-  if (diffName) {
-    // We need this replacement to not break the body string
-    diffblock = fs.readFileSync(diffName, 'utf8');
-    diffblock = diffblock.replaceAll('```', '');
-  }
-
-  return fetch(`https://api.github.com/repos/${repo}/issues`, {
-    method: 'POST',
-    headers: getRequestHeaders(),
-    body: JSON.stringify({
-      title: `Translate \`${shorterName}\`, Ember ${newEmberVersion}`,
-      body: getIssueBody(filename, diffblock),
-      labels: ['Guides FR trad']
-    })
-  });
-}
-
-const openCatchupPR = () => {
-  return fetch(`https://api.github.com/repos/${repo}/pulls`, {
-    method: 'POST',
-    headers: getRequestHeaders(),
-    body: JSON.stringify({
-      title: `Catch up latest docs: from ${currentEmberVersion} to ${newEmberVersion}`,
-      body: 'This is an automatic catch up PR to align our non-translated documentation with the latest official documentation.',
-      head: catchupBranch,
-      base: 'master',
-      labels: ['Guides FR trad']
-    })
-  });
-}
-
-/*
- * This function post a GitHub issue for each file that couldn't be patched automatially.
- * It works with a classic for loop that pauses the execution during the request and wait one second after the answer is received.
- * This is done to control timing and concurrency, as explained in GitHub API documentation.
- */
-const postAllIssues = async () => {
-  for (const file of filesToPost) {
-    try {
-      console.log(`Attempting to open an issue for ${file.filename}`);
-      const response = await postIssue(file);
-      const jsonResponse = await response.json();
-      console.log('Server responded with:', jsonResponse);
-    } catch (error) {
-      console.warn('Issue posting has failed:', error);
-      warnings.push(`
-ACTION REQUIRED: The issue for file ${file.filename} (${file.diffName}) couldn't be opened automatically.
--> Open it manually using the dedicated issue template.
-
-`);
-      issuePostingError = true;
-    } finally {
-      await new Promise(resolve => setTimeout(resolve, 1000));
-    }
-  };
-
-  // If one of the post failed, we keep the diff files so we can easily open the issue manually
-  if (issuePostingError) {
-    console.warn("At least one Github issue was not posted, scripts/patches folder won't be deleted so missing issues can be posted manually");
-  } else {
-    try {
-      // If and once the issues are posted, delete patches folder and files
-      fs.rmSync('scripts/patches', { recursive: true, force: true });
-      console.log('scripts/patches folder and files did their job, deleted');
-    } catch(error) {
-      console.warn('Failed to delete the folder scripts/patches and its content.')
-    }
-  }
-}
-
-/*
- * This function adds, commits, and pushes the modifications in "guides" folder
- */
-const pushChanges = () => {
-  try {
-    runShell('git add guides');
-    runShell(`git commit -m "feat: automatic catch up from ${currentEmberVersion} to ${newEmberVersion}"`);
-    runShell(`git push origin ${catchupBranch}`);
-  } catch (error) {
-    warnings.push(`
-ACTION REQUIRED: Failed to push the catchup branch
--> Check what's the issue, then push the changes and open the Github PR manually.
-
-`);
-    throw error;
-  }
-}
-
-/*
- * This function performs a switch to the master branch.
- * The error message highlights the fact this is perform at the end of the process,
- * to warn the developer that despite this last error, the process is completed.
- */
-const switchToMaster = () => {
-  try {
-    runShell('git switch master');
-  } catch (error) {
-    console.warn('The process is complete, but failed to switch back to master');
-  }
-}
-
-/*
- * This function performs a switch to the catchup branch.
- * The success message highlights the fact this is perform at the end of the process, 
- * to exit on the catchup branch so post failures can be easily handled manually.
- */
-const switchToCatchup = () => {
-  try {
-    runShell(`git switch ${catchupBranch}`);
-    console.log('Stay on the catchup branch at the end of the process, so non-posted issues can be handled.');
-  } catch (error) {
-    console.warn(`The process is complete, but failed to switch back to ${catchupBranch}`);
-    warnings.push(`
-ACTION REQUIRED: The process failed to switch back to ${catchupBranch}. 
--> Switch manually to ${catchupBranch} then complete the other required actions.
-
-  `);
-  }
-}
-
-/*
- * This function switches to the ref-upstream branch to reset it to the latest upstream/master,
- * then it pushes ref-upstream branch to the origin repository.
- */
-const updateRefUpstream = () => {
-  try {
-    runShell('git switch ref-upstream');
-    runShell('git reset --hard upstream/master');
-    runShell('git push origin -f ref-upstream');
-  } catch (error) {
-    warnings.push(`
-ACTION REQUIRED: The process failed to reset ref-upstream to the latest upstream/master. 
+function gitIssueOnUpdateRefUpstream() {
+  return action(`The process is complete, but failed to reset ref-upstream to the latest upstream/master. 
 -> Perform manually:
 * git switch ref-upstream
 * git reset --hard upstream/master
 * git push origin -f ref-upstream
-  `);
-    throw new Error('Failed to reset ref-upstream to the latest upstream/master');
-  }
+
+  `)
 }
 
-/*
- * This function performs the last actions once most of the catchup is done
- * It updates ref-upstream to upstream/master if there's no pending manual action,
- * then it switches back to master.
- */
-const closeProcess = () => {
-  if (hasPendingDiff) {
-    warnings.push(`
-ACTION REQUIRED: To manage some of the warnings above, you might need to use ref-upstream in its current state, so it was not updated. 
--> Once you are done with everything above, run:
- * git switch ref-upstream
- * git reset --hard upstream/master
- * git push origin -f ref-upstream
+function requestIssueSummary() {
+  return action(`Some of the steps failed while opening the GitHub issues and catchup branch.
+-> Follow all the ACTION REQUIRED above to complete the catchup.
+  Once this is done, run:
+    * git switch ref-upstream
+    * git reset --hard upstream/master
+    * git push origin -f ref-upstream
 
   `);
-  }
-  else {
-    try {
-      /* Reset ref-upstream to the current upstream/master to get ready for the next catchup
-       * ref-upstream should always match the version under translation */
-      updateRefUpstream();
-
-      /* Then go back to master only if there's no diff file to post manually.
-       * If there are diff files to post manually, then it's more convinient to stay on the catchup branch */
-      if (!issuePostingError) {
-        switchToMaster();
-      } else {
-        switchToCatchup();
-      }
-    } catch(error) {
-      throw error;
-    }
-  }
 }
 
 try {
-
-  try {
-    // Create a catchup branch out of the current branch (should be up to date master)
-    runShell(`git switch --create ${catchupBranch}`);
-    // Fetch the latest ref-upstream branch (English version under translation on this repo)
-    runShell('git fetch');
-    // Fetch the latest updates in the official Ember Guides
-    runShell('git fetch upstream');
-    // Output the list of markdown files impacted by latest changes on upstream
-    runShell('git diff --name-only origin/ref-upstream upstream/master -- guides/release > list.diff');
-  } catch (error) {
-    throw new Error('Failed to create the diff between origin/ref-upstream and upstream/master in a new branch. The catchup cannot continue.');
-  }
-
-  // Read list.diff to extract the list of path to markdown files
+  // Create and read list.diff to extract the list of filenames that changed between origin/ref-upstream and upstream/master
+  initCatchup(catchupBranch);
   let data = fs.readFileSync('list.diff', 'utf8');
-  files = data.split(/[\n\r]/).filter(name => name.length);
-  fs.unlink('list.diff', function(err) {
-    if (err) {
-      console.warn('Failed to delete list.diff');
-    } else {
-      console.log('list.diff did its job, deleted');
-    }
-  });
+  let files = data.split(/[\n\r]/).filter(name => name.length);
 
   // If there's no diff in the guides part, we can stop here
-  if (files && files.length > 0) {
-
-    // Create a directory to put the children diff
-    fs.mkdirSync('scripts/patches', { recursive: true });
-    console.log('scripts/patches folder created to store the patch files');
-
-    /* Try to apply the diff files automatically and keep track of the failed and new ones.
-     * hasAutoApply is true if at least one file could be patched automatically. */
-    let hasAutoApply = await writeDiffFiles();
-    console.log('Files to post on GitHub:', filesToPost);
-
-    /* Post Github issues for diff files that couldn't be handled automatically
-     * we await so the POST for issues and the POST for the catchup PR below are not done at the same time */
-    await postAllIssues();
-
-    // Post the catchup PR if there's at least one patched file to commit
-    if (hasAutoApply) {
-      try {
-        pushChanges();
-
-        try {
-          console.log('Attempting to post the catch up PR');
-          const prResponse = await openCatchupPR();
-          const jsonPrResponse = await prResponse.json();
-          console.log('Server responded with:', jsonPrResponse);
-        } catch (error) {
-          console.warn(`Failed to post the catchup PR. This was caused by: ${error}`);
-          warnings.push(`
-ACTION REQUIRED: The catchup PR was not opened automatically on GitHub.
--> Chack what's the issue, then open the PR on GitHub manually.
-  
-  `);
-        }
-
-      } catch (error) {
-        console.warn('Failed to push the catchup branch.');
-      }
+  if (!files && !files.length) {
+    success('No change between both versions of the Ember Guides.')
+    try {
+      updateRefUpstream()
+    } catch(error) {
+      printActionsRequired([gitIssueOnUpdateRefUpstream()])
     }
-
-  } else {
-    console.log('No change between both versions of the Ember Guides.');
   }
 
-  closeProcess();
-  printWarningMessages();
+  /* 
+   * Process the diff:
+   * For each file, processFiles creates an indivitual patch file
+   * and tries to "git apply" it automatically.
+   */
+  let { 
+    filesToPost, // These are the files - new or translated - that require a GitHub issue to be handled by translators
+    hasAutoApply, // This is true if at least one file has been patched automatically, so we'll have to open a PR to merge the patch
+    hasDiffIssues, // This is true if there was a problem while processing the patch files
+    actionsRequired // These are the manual actions to do to get a ready-for-GitHub list of patches if something went wrong.
+  } = await processFiles(files);
 
+  // If there were issues processing the file, we stop the catchup and simply explain how to terminate it manually 
+  if (hasDiffIssues) {
+    actionsRequired.push(fsIssueOnApplyPatches());
+    printActionsRequired(actionsRequired);
+    throw new Error('Something went wront while processing the patch files');
+  }
+
+  // Object in charge to perform requests to GitHub API
+  const githubAdapter = new GitHubAdapter(
+    REPO,
+    process.env.GITHUB_TOKEN,
+    currentEmberVersion,
+    newEmberVersion,
+    catchupBranch
+  );
+
+  /* 
+   * Post GitHub issues for diff files that couldn't be handled automatically.
+   * We await so the POST for issues and the POST for the catchup PR below are not done at the same time. 
+   * The returned actionRequired keep track of the failed request, so we can easily complete the catchup manually
+   */
+  actionsRequired = await githubAdapter.postAllIssues(filesToPost);
+
+  // If there's at least one patched file to commit, let's commit it and open a catch-up PR
+  if (hasAutoApply) {
+    try {
+      pushGuides(currentEmberVersion, newEmberVersion, catchupBranch)
+      try {
+        log('Attempting to post the catch up PR');
+        await githubAdapter.openCatchupPR();
+        success('Server responded successfully');
+      } catch (error) {
+        raise(`Failed to post the catchup PR. This was caused by: ${error}`);
+        actionsRequired.push(requestIssueOnOpenPR());
+      }
+    } catch (error) {
+      raise(error);
+      actionsRequired.push(gitIssueOnPushGuides());
+    }
+  }
+
+  // If at least one request failed, we stop the catchup and print the explanations to complete manually
+  if (actionsRequired.length > 0) {
+    actionsRequired.push(requestIssueSummary());
+    printActionsRequired(actionsRequired);
+    throw new Error('Something went wrong while posting the GitHub issues and catchup branch');
+  }
+
+  try {
+    updateRefUpstream()
+    try {
+      runShell('git switch master');
+    } catch (error) {
+      warn('The catchup is fully completed, but the process failed to switch back to master');
+    }
+  } catch(error) {
+    printActionsRequired([gitIssueOnUpdateRefUpstream()]);
+    throw new Error(error);
+  }
+  
+  // Files clean-up
+  try {
+    fs.unlinkSync('list.diff');
+    fs.rmSync('scripts/patches', { recursive: true, force: true });
+    log('list.diff and scripts/patches folder and files did their job, deleted');
+  } catch(error) {
+    warn('The catchup is fully completed, but the process failed to delete list.diff, scripts/patches folder and its content.')
+  }
 } catch (error) {
-  console.error(error);
-  printWarningMessages();
+  raise(error);
   process.exitCode = 1;
 }

--- a/scripts/catchup/filesProcessor.mjs
+++ b/scripts/catchup/filesProcessor.mjs
@@ -1,0 +1,131 @@
+import chalk from 'chalk'
+import { existsSync, mkdirSync } from 'fs'
+import { readFile, writeFile } from 'fs/promises'
+import { log, raise, action, runShell, success, warn } from "./logger.mjs"
+import { createDiff } from "./gitActions.mjs"
+
+function patchIssueOnRead(diffName) {
+  return action(`The patch paths could not be edited for ${chalk.magenta.bold(diffName)} because the file couldn't be read.
+-> Check what's the issue then edit the path manually:
+* Find and replace "guides/release" with "guides" in ${chalk.magenta.bold(diffName)}
+* Run "git apply ${chalk.magenta.bold(diffName)}"
+  If the command is successful, commit the file.
+  If the command fails, open a GitHub issue and copy the diff using the provided issue template.
+  
+  `)
+}
+
+function patchIssueOnEdit(diffName) {
+  return action(`The patch paths could not be edited for ${chalk.magenta.bold(diffName)} because the file couldn't be edited.
+-> Check what's the issue then edit the path manually:
+* Find and replace "guides/release" with "guides" in ${chalk.magenta.bold(diffName)}
+* Run "git apply ${chalk.magenta.bold(diffName)}"
+  If the command is successful, commit the file.
+  If the command fails, open a GitHub issue and copy the diff using the provided issue template.
+  
+  `)
+}
+
+/*
+ * Looks for the paths guides/release in the provided string and replaces it with guides.
+ * We need this to adjust the paths to our scaffolding:
+ * The official English guides allow to navigate to legacy versions of Ember, it's "versioned" docs.
+ * The French guides show only the latest version, so we don't have a dropdown to navigate, it's "unversioned" docs.
+ * It's the scaffolding of the guides folder that impacts the dropdown presence: instead of having a release/ folder
+ * that corresponds to the latest version, we have the docs at the root of guides directly.
+ */
+function unversionPath(stringContent) {
+  return stringContent.replace(/guides\/release/g, 'guides')
+}
+
+/* 
+ * Executes all the read/write operations on diff files.
+ * files is the list of files (as paths) that changed between ref-upstream and upstream/master
+ */
+async function applyPatches(files) {
+  /* 
+   * List of { filename, diffname} that will require a GitHub issue to be adjust manually
+   * Example: pushing { filename: "my-page.md", diffName: "3.diff" } in this array means that
+   * the diff between origin/ref-upstream and upstream/master for the file "my-page.md" has been printed in "3.diff".
+   * The command "git apply 3.diff" failed, probably because "my-page.md" was already translated into French.
+   * Therefore, we need to open a GitHub issue showing the diff English to English so translators know how to adjust the translation.
+   */
+  let filesToPost = []
+  let actionsRequired = []
+
+  // This is an array of promises we're going to run in parallel to process all the diff files
+  let writePromises = await files.map(async (filename, index) => {
+    // Matching Guidemaker scaffolding consists in replacing path guides/release with guides
+    const unversionedFileName = unversionPath(filename)
+    let diffName
+  
+    try {
+      // We create the diff between origin/ref-upstream and upstream/master
+      diffName = createDiff(filename, index)
+      // Then we read the content of the newly created diff
+      let fileContent
+      try {
+        fileContent = await readFile(diffName, 'utf8')
+      } catch (error) {
+        actionsRequired.push(patchIssueOnRead(diffName))
+        throw new Error(`Failed to read ${chalk.magenta.bold(diffName)} to edit the patch path. This was caused by: ${error}`)
+      }
+      // To replace all paths to guides/release with guides
+      try {
+        const replacement = unversionPath(fileContent)
+        fileContent = await writeFile(diffName, replacement, 'utf8')
+        success(`Path in ${chalk.bold(diffName)} updated`)
+      } catch (error) {
+        actionsRequired.push(patchIssueOnEdit(diffName))
+        throw new Error(`Failed to write ${chalk.magenta.bold(diffName)} to edit the patch path. This was caused by: ${error}`)
+      }
+    } catch (error) {
+      raise(error)
+      return 1
+    }
+
+    // Once diff paths are ready, run "git apply" to patch the markdown file automatically
+    try {
+      // Does the current file already exist or is it a new page in the Ember Guides?
+      let isNew = !existsSync(unversionedFileName)
+      // git apply runs after we've initialized isNew, because it can create the missing file
+      runShell(`git apply ${diffName}`)
+      // If the page is new, git apply works but we still need to push an issue for the 1st translation
+      if (isNew) filesToPost.push({ filename: unversionedFileName })
+      return 0
+    } catch (error) {
+      // git apply fails if the file was modified on both sides, so it's an already-translated file
+      warn(`"git apply" command failed for ${chalk.magenta.bold(diffName)}`)
+      filesToPost.push({ filename: unversionedFileName, diffName })
+      return 2
+    }
+  })
+
+  log('Ready to create the patch files')
+  let result = await Promise.all(writePromises)
+
+  const hasDiffIssues = result.some((status) => status === 1)
+  if (hasDiffIssues) {
+    raise('Writing operations terminated with errors. Some of the patch files are applied or stored in scripts/patches/, and items have been added to the "action required" list.')
+  } else {
+    success('All writing operations completed without errors, patch files are applied or stored in scripts/patches/')
+  }
+  return { 
+    filesToPost,
+    hasAutoApply: result.some((status) => status === 0),
+    hasDiffIssues,
+    actionsRequired,
+  }
+}
+
+export async function processFiles(files) {
+  // Create a directory to put the children diff
+  mkdirSync('scripts/patches', { recursive: true });
+  log('scripts/patches folder created to store the patch files');
+
+  /* Try to apply the diff files automatically and keep track of the failed ones.
+    * hasAutoApply is true if at least one file could be patched automatically. */
+  let results = await applyPatches(files);
+  log(`Files to post on GitHub: ${chalk.bold.magenta(results.filesToPost.map(({ filename }) => filename))}`);
+  return results;
+}

--- a/scripts/catchup/gitActions.mjs
+++ b/scripts/catchup/gitActions.mjs
@@ -1,0 +1,57 @@
+import { runShell } from "./logger.mjs";
+
+export function initCatchup(catchupBranch) {
+  try {
+    // Create a catchup branch out of the current branch (should be up to date master)
+    runShell(`git switch --create ${catchupBranch}`);
+    // Fetch the latest ref-upstream branch (English version under translation on this repo)
+    runShell('git fetch');
+    // Fetch the latest updates in the official Ember Guides
+    runShell('git fetch upstream');
+    // Output the list of markdown files impacted by latest changes on upstream
+    runShell('git diff --name-only origin/ref-upstream upstream/master -- guides/release > list.diff');
+  } catch (error) {
+    throw new Error('Failed to create the diff between origin/ref-upstream and upstream/master in a new branch');
+  }
+}
+
+// Adds, commits, and pushes the modifications only in "guides" folder
+export function pushGuides(currentEmberVersion, newEmberVersion, catchupBranch) {
+  try {
+    runShell('git add guides');
+    runShell(`git commit -m "feat: automatic catch up from ${currentEmberVersion} to ${newEmberVersion}"`);
+    runShell(`git push origin ${catchupBranch}`);
+  } catch (error) {
+    throw new Error('Failed to push the catchup branch.');
+  }
+}
+
+/* 
+ * Reset ref-upstream to the current upstream/master to get ready for the next catchup
+ * ref-upstream should always match the version under translation
+*/
+export function updateRefUpstream() {
+  try {
+    runShell('git switch ref-upstream');
+    runShell('git reset --hard upstream/master');
+    runShell('git push origin -f ref-upstream');
+  } catch (error) {
+    throw new Error('Failed to reset ref-upstream to the latest upstream/master');
+  }
+}
+
+/* 
+ * Compares the given filename in both branches and output a [index].diff file.
+ * Example: 
+ * filename = guides/accessibility/index.md, index = 3
+ * The diff between ref-upstream and upstream/master for this file is printed in 3.diff
+ */
+export function createDiff(filename, index) {
+  const diffName = `scripts/patches/${index}.diff`;
+  try {
+    runShell(`git diff ref-upstream upstream/master -- ${filename} > ${diffName}`);
+    return diffName;
+  } catch (error) {
+    throw new Error(`Failed to create the diff for ${filename}. This was caused by: ${err}`);
+  }
+}

--- a/scripts/catchup/github.mjs
+++ b/scripts/catchup/github.mjs
@@ -1,0 +1,118 @@
+
+import chalk from 'chalk'
+import { readFileSync } from 'fs';
+import { log, action, raise, success } from './logger.mjs'
+
+function issueTitle(shorterName, newEmberVersion) {
+  return `Translate \`${shorterName}\`, Ember ${newEmberVersion}`
+}
+
+function issueBody(filename, currentEmberVersion, newEmberVersion, diffName) {
+  return `
+Please assign yourself to the issue or let a comment at the very moment you start the translation.
+
+File: \`${filename}\`
+From Ember: **${currentEmberVersion}**
+To Ember: **${newEmberVersion}**
+
+${issueBodyDiff(diffName)}
+`
+}
+
+/* 
+ * Generates the code snippet of the Github issues posted by postIssue function.
+ * Note the diffName can be undefined if the file was initially non-existing in origin/ref-upstream branch,
+ * this case happens when new pages are added to the latest version of the Ember Guides.
+ */
+function issueBodyDiff(diffName) {
+  if (!diffName) return 'This is the first translation for this file.'
+
+  // We need this replacement to not break the body string
+  let diffblock = readFileSync(diffName, 'utf8');
+  diffblock = diffblock.replaceAll('```', '');
+
+  return `
+In the snippet below, you can see what changes were done in the latest English documentation. The purpose of this issue is to adjust the French translation to match the new version:
+
+\`\`\`diff
+${diffblock}
+\`\`\`
+`
+}
+
+export default class GitHubAdapter {
+  constructor(repo, token, currentEmberVersion, newEmberVersion, catchupBranch) {
+    this.repo = repo
+    this.token = token
+    this.currentEmberVersion = currentEmberVersion
+    this.newEmberVersion = newEmberVersion
+    this.catchupBranch = catchupBranch
+  }
+
+  /* 
+   * Returns the headers required for all requests to GitHub API.
+   * It includes both posting issues and opening the catchup PR.
+   */
+  _getRequestHeaders() {
+    return {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `token ${this.token}`,
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  }
+
+  /*
+   * Posts a GitHub issue for each file that couldn't be patched automatially.
+   * It works with a classic for loop that pauses the execution during the request and wait one second after the answer is received.
+   * This is done to control timing and concurrency, as explained in GitHub API documentation.
+   */
+  async postAllIssues(filesToPost) {
+    let actionRequired = [];
+    for (const file of filesToPost) {
+      try {
+        log(`Attempting to open an issue for ${chalk.magenta(file.filename)}`);
+        await this.postIssue(file);
+        success('Server responded successfully');
+      } catch (error) {
+        raise('Issue posting has failed:', error);
+        actionRequired.push(action(`The issue for file ${file.filename} (${file.diffName}) couldn't be opened automatically.
+ -> Open it manually using the dedicated issue template.
+`));
+      } finally {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    };
+    return actionRequired;
+  }
+
+  async postIssue(file) {
+    const { filename, diffName } = file;
+    const shorterName = filename.substring(6);
+
+    let response = await fetch(`https://api.github.com/repos/${this.repo}/issues`, {
+      method: 'POST',
+      headers: this._getRequestHeaders(this.token),
+      body: JSON.stringify({
+        title: issueTitle(shorterName, this.newEmberVersion),
+        body: issueBody(filename, this.currentEmberVersion, this.newEmberVersion, diffName),
+        labels: ['Guides FR trad']
+      })
+    });
+    return response.json();
+  }
+
+  async openCatchupPR() {
+    let response = await fetch(`https://api.github.com/repos/${this.repo}/pulls`, {
+      method: 'POST',
+      headers: this._getRequestHeaders(this.token),
+      body: JSON.stringify({
+        title: `Catch up latest docs: from ${this.currentEmberVersion} to ${this.newEmberVersion}`,
+        body: 'This is an automatic catch up PR to align our non-translated documentation with the latest official documentation.',
+        head: this.catchupBranch,
+        base: 'master',
+        labels: ['Guides FR trad']
+      })
+    });
+    return response.json();
+  }
+}

--- a/scripts/catchup/logger.mjs
+++ b/scripts/catchup/logger.mjs
@@ -1,0 +1,50 @@
+import chalk from 'chalk'
+import { execSync } from 'child_process'
+
+// A shortcut for console.log
+export const log = console.log
+
+// Prints fancy success
+export function success(message) {
+  log(`${chalk.green(message)} ✓`)
+}
+
+// Prints fancy error
+export function raise(message) {
+  log(`${chalk.red('Error:')} ${message}`)
+}
+
+// Prints fancy warning
+export function warn(message) {
+  log(`${chalk.yellow('Warning:')} ${message}`)
+}
+
+// Returns fancy action required
+export function action(message) {
+  return `${chalk.blueBright('ACTION REQUIRED:')} ${message}`
+}
+
+/* 
+ * Executes a shell command using execSync with an additional log.
+ * If the command failed, execSync throws the error, so use runShell inside a try...catch.
+ */
+export function runShell(command) {
+  log(`Attempting to execute: "${chalk.bold(command)}"`);
+  execSync(command);
+}
+
+/*
+ * Prints the messages stored in warnings.
+ * Should always be called before forcing the process to exit.
+ */
+export function printActionsRequired(warnings) {
+  if (!warnings.length) return
+  log(`
+The process has been completed with warnings.
+Here are all the actions you should perform manually to fully complete it:
+
+`)
+  for (const warning of warnings) {
+    warn(warning)
+  }
+}


### PR DESCRIPTION
Relates to #220 (doesn't close it because I consider replacing the argument parser)

This PR implements a new, nicer version of the catchup script:
- The script is split into several files for better readability and maintenance. 
- Multiline messages are returned by dedicated functions to avoid big text blocks in the middle of the logic, making the process easier to follow.
- Additionally, requests to the GitHub API are managed by an instance of a `GithubAdapter` class that can be constructed with all the parameters required for the different requests.
- The possible execution paths have been simplified: the script doesn't make it to the API requests if there's an issue with file writing and never updates `ref-upstream` nor switches back to `master` if there's anything manual to do.
- The library `chalk` is used to add colors and styles to the different messages, which greatly improves the readability of the output.
- `shelljs` was used in the 1st version of the script, it should have been uninstalled sooner.

Note it has been implemented and tested in a dedicated repository.